### PR TITLE
Fix a race condition caused by passing a pointer from range between threads

### DIFF
--- a/Filewatcherd-Go/src/codewind/fsnotify.go
+++ b/Filewatcherd-Go/src/codewind/fsnotify.go
@@ -64,14 +64,14 @@ func NewWatchService(projectList *ProjectList, baseUrl string, clientUUID string
 	return result
 }
 
-func (service *WatchService) AddRootPath(path string, projectFromWS *models.ProjectToWatch) {
+func (service *WatchService) AddRootPath(path string, projectFromWS models.ProjectToWatch) {
 
 	debugStr := "Add " + projectFromWS.ProjectID + " @" + time.Now().String()
 
 	msg := &AddRemoveRootPathChannelMessage{
 		true,
 		path,
-		projectFromWS,
+		&projectFromWS,
 		debugStr,
 	}
 
@@ -84,12 +84,12 @@ func (service *WatchService) AddRootPath(path string, projectFromWS *models.Proj
 
 }
 
-func (service *WatchService) RemoveRootPath(path string, projectFromWS *models.ProjectToWatch) {
+func (service *WatchService) RemoveRootPath(path string, projectFromWS models.ProjectToWatch) {
 	debugStr := "Remove " + projectFromWS.ProjectID + " @" + time.Now().String()
 	msg := &AddRemoveRootPathChannelMessage{
 		false,
 		path,
-		projectFromWS,
+		&projectFromWS,
 		debugStr,
 	}
 

--- a/Filewatcherd-Go/src/codewind/models/models.go
+++ b/Filewatcherd-Go/src/codewind/models/models.go
@@ -21,6 +21,38 @@ type ProjectToWatch struct {
 	Type                       string   `json:"type"`
 }
 
+/** This is not currently used, but I reserve the right to clone all the things at a later date. */
+func (entry *ProjectToWatch) Clone() *ProjectToWatch {
+
+	var newIgnoredFilenames []string
+
+	if entry.IgnoredFilenames != nil {
+		newIgnoredFilenames = make([]string, 0)
+		for _, val := range entry.IgnoredFilenames {
+			newIgnoredFilenames = append(newIgnoredFilenames, val)
+		}
+	}
+
+	var newIgnoredPaths []string
+
+	if entry.IgnoredPaths != nil {
+		newIgnoredPaths = make([]string, 0)
+		for _, val := range entry.IgnoredPaths {
+			newIgnoredPaths = append(newIgnoredPaths, val)
+		}
+	}
+
+	return &ProjectToWatch{
+		newIgnoredFilenames,
+		newIgnoredPaths,
+		entry.PathToMonitor,
+		entry.ProjectID,
+		entry.ChangeType,
+		entry.ProjectWatchStateID,
+		entry.Type,
+	}
+}
+
 type WatchlistEntries []ProjectToWatch
 
 type WatchlistEntryList struct {

--- a/Filewatcherd-Go/src/codewind/utils/logger.go
+++ b/Filewatcherd-Go/src/codewind/utils/logger.go
@@ -87,7 +87,14 @@ func LogErrorErr(msg string, err error) {
 	if l.logLevel > ERROR {
 		return
 	}
-	l.err("! ERROR !: " + msg + " - Error:" + err.Error())
+
+	outputMsg := "! ERROR !: " + msg
+
+	if err != nil {
+		outputMsg += " - Error:" + err.Error()
+	}
+
+	l.err(outputMsg)
 }
 
 func LogSevere(msg string) {
@@ -96,8 +103,15 @@ func LogSevere(msg string) {
 }
 
 func LogSevereErr(msg string, err error) {
+
+	outputMsg := "!!! SEVERE !!!: " + msg
+
+	if err != nil {
+		outputMsg += " - Error:" + err.Error()
+	}
+
 	l := loggerInternal()
-	l.err("!!! SEVERE !!!: " + msg + " - Error:" + err.Error())
+	l.err(outputMsg)
 }
 
 func (l *MonitorLogger) out(msg string) {

--- a/Filewatcherd-TypeScript/src/lib/ProjectObject.ts
+++ b/Filewatcherd-TypeScript/src/lib/ProjectObject.ts
@@ -31,7 +31,7 @@ export class ProjectObject {
 
         if (existingProjectToWatch.pathToMonitor !== newProjectToWatch.pathToMonitor ) {
 
-            const msg = "The path to monitor of a project cannot be changed once it set, for a particular project id";
+            const msg = "The pathToMonitor of a project cannot be changed once it is set, for a particular project id";
 
             log.severe(msg);
         }

--- a/org.eclipse.codewind.filewatchers.core/src/org/eclipse/codewind/filewatchers/core/Filewatcher.java
+++ b/org.eclipse.codewind.filewatchers.core/src/org/eclipse/codewind/filewatchers/core/Filewatcher.java
@@ -564,7 +564,7 @@ public class Filewatcher {
 				ProjectToWatch existingProjectToWatch = project_synch_lock;
 				if (!existingProjectToWatch.getPathToMonitor().equals(newProjectToWatch.getPathToMonitor())) {
 
-					String msg = "The path to monitor of a project cannot be changed once it set, for a particular project id";
+					String msg = "The path to monitor of a project cannot be changed once it is set, for a particular project id";
 
 					log.logSevere(msg, null, existingProjectToWatch.getProjectId());
 				}


### PR DESCRIPTION
Issue was due to acquiring and passing around the pointer of a value from `range`, which works fine when the pointer remains within the context of the single-thread, but fails miserabley when the pointer is passed between threads, even when the actual object pointed to is defacto immutable.

The offending block:
```
for _, project := range *entries {
	processProject(&project, projectsMap, postOutputQueue, watchService)
}
```
Here, `project` is a copy of the `ProjectToWatch` struct, and `&project` points to the most recent struct copy in memory, thus passing around the pointer to `project` will cause the pointer to point to a new struct on every iteration of the for block (thus when other threads try to access the project from this pointer, they will see a different project then the one that was expected.)
