### PR TITLE
Every X minutes, output the internal state of the Go filewatcher service

### DIFF
--- a/Filewatcherd-Go/src/codewind/clientmain.go
+++ b/Filewatcherd-Go/src/codewind/clientmain.go
@@ -52,6 +52,9 @@ func main() {
 
 	StartWSConnectionManager(baseURL, projectList, httpGetStatusThread)
 
+	debugTimer := NewDebugTimer(watchService, projectList, httpPostOutputQueue)
+	debugTimer.Start()
+
 	for {
 		time.Sleep(1000 * time.Millisecond)
 	}

--- a/Filewatcherd-Go/src/codewind/debugtimer.go
+++ b/Filewatcherd-Go/src/codewind/debugtimer.go
@@ -37,7 +37,7 @@ func NewDebugTimer(watchService *WatchService, projectList *ProjectList, postOut
 func (debugTimer *DebugTimer) Start() {
 
 	// This is intentionally a timer, and not a ticker.
-	timer := time.NewTimer(10 * time.Second)
+	timer := time.NewTimer(30 * time.Minute)
 	go func() {
 		for range timer.C {
 			debugTimer.OutputDebug()

--- a/Filewatcherd-Go/src/codewind/debugtimer.go
+++ b/Filewatcherd-Go/src/codewind/debugtimer.go
@@ -1,0 +1,71 @@
+/*******************************************************************************
+* Copyright (c) 2019 IBM Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v2.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
+
+package main
+
+import (
+	"codewind/utils"
+	"strings"
+	"time"
+)
+
+type DebugTimer struct {
+	watchService    *WatchService
+	projectList     *ProjectList
+	postOutputQueue *HttpPostOutputQueue
+}
+
+func NewDebugTimer(watchService *WatchService, projectList *ProjectList, postOutputQueue *HttpPostOutputQueue) *DebugTimer {
+	result := &DebugTimer{
+		watchService,
+		projectList,
+		postOutputQueue,
+	}
+
+	return result
+}
+
+/** Start (or restart) the timer */
+func (debugTimer *DebugTimer) Start() {
+
+	// This is intentionally a timer, and not a ticker.
+	timer := time.NewTimer(10 * time.Second)
+	go func() {
+		for range timer.C {
+			debugTimer.OutputDebug()
+			return // Exit the goroutine after one invocation, to terminate the thread/channel
+		}
+	}()
+}
+
+func (debugTimer *DebugTimer) OutputDebug() {
+
+	result := ""
+
+	result += "---------------------------------------------------------------------------------------\n\n"
+
+	watchServiceResult := <-debugTimer.watchService.RequestDebugMessage()
+	result += "WatchService:\n" + strings.TrimSpace(watchServiceResult) + "\n\n"
+
+	result += "Project List:\n" + strings.TrimSpace(<-debugTimer.projectList.RequestDebugMessage()) + "\n\n"
+
+	result += "HTTP Post Output Queue:\n" + strings.TrimSpace(<-debugTimer.postOutputQueue.RequestDebugMessage()) + "\n\n"
+
+	result += "---------------------------------------------------------------------------------------\n"
+
+	for _, val := range strings.Split(result, "\n") {
+
+		utils.LogInfo("[status] " + val)
+	}
+
+	// Restart the timer
+	debugTimer.Start()
+}

--- a/Filewatcherd-Go/src/codewind/fsnotify.go
+++ b/Filewatcherd-Go/src/codewind/fsnotify.go
@@ -365,7 +365,7 @@ func startWatcher(cWatcher *CodewindWatcher, path string, projectList *ProjectLi
 
 		watcherFuncID := strconv.FormatUint(rand.Uint64(), 10)
 
-		debugUpdateTimer := time.NewTicker(5 * time.Second)
+		debugUpdateTimer := time.NewTicker(10 * time.Minute)
 
 		for {
 			select {

--- a/Filewatcherd-Go/src/codewind/utils/utils.go
+++ b/Filewatcherd-Go/src/codewind/utils/utils.go
@@ -14,6 +14,7 @@ package utils
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 	"strings"
 	"time"
 )
@@ -102,4 +103,14 @@ func GenerateUuid() *string {
 	result := hex.EncodeToString(u)
 
 	return &result
+}
+
+func FormatTime(t time.Time) string {
+
+	formatted := "[" + fmt.Sprintf("%d-%02d-%02d %02d:%02d:%02d.%03d",
+		t.Year(), t.Month(), t.Day(),
+		t.Hour(), t.Minute(), t.Second(), (t.Nanosecond()/1000000)) + "]"
+
+	return formatted
+
 }

--- a/Filewatcherd-Go/src/codewind/ws.go
+++ b/Filewatcherd-Go/src/codewind/ws.go
@@ -14,12 +14,12 @@ package main
 import (
 	"codewind/models"
 	"codewind/utils"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"net/url"
 	"strconv"
 	"strings"
-	"crypto/tls"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -92,12 +92,13 @@ func startWebSocketThread(wsURLType string, hostnameAndPort string, triggerRetry
 
 	var c *websocket.Conn
 
+	// Keep trying to connect on the WebSocket thread, until success
 	for {
 
 		utils.LogInfo("Connecting to " + u.String())
 
 		dialer := &websocket.Dialer{}
-		dialer.TLSClientConfig = &tls.Config{ InsecureSkipVerify : true }
+		dialer.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 
 		innerC, _, err := dialer.Dial(u.String(), nil)
 


### PR DESCRIPTION

Every X minutes, output the internal state of the Go filewatcher service:
```
 WatchService:
 - 863e54127c80f6b2ca571331cf908761 | c:\Users\JONATH~1\AppData\Local\Temp\fw-test-4025153296823677314\.config | (open)
   - c:\Users\JONATH~1\AppData\Local\Temp\fw-test-4025153296823677314\.config
 - d75054f0-91f2-11e9-95b2-abffdcae5cb9 | c:\Users\JONATH~1\AppData\Local\Temp\fw-test-4025153296823677314\goproj | (open)
   - c:\Users\JONATH~1\AppData\Local\Temp\fw-test-4025153296823677314\goproj

 Project List:
 - d75054f0-91f2-11e9-95b2-abffdcae5cb9 -> /c/Users/JONATH~1/AppData/Local/Temp/fw-test-4025153296823677314/goproj | lastFileChangeSeen: er: [2019-07-08 13:48:33.733]
 - 863e54127c80f6b2ca571331cf908761 -> /c/Users/JONATH~1/AppData/Local/Temp/fw-test-4025153296823677314/.config | lastFileChangeSeen: er: [2019-07-08 13:48:33.731]

 HTTP Post Output Queue:
 - active-workers: 1  chunkGroupList-size: 2

 - HTTP Post Chunk Group List:
   - projectID:   timestamp: 1562608112730
   - projectID:   timestamp: 1562608112732
```