### PR TITLE
Improve native VSCode integration in TypeScript filewatcher

### DIFF
--- a/Filewatcherd-TypeScript/src/lib/FileLogger.ts
+++ b/Filewatcherd-TypeScript/src/lib/FileLogger.ts
@@ -39,7 +39,8 @@ export class FileLogger {
         this._logDir = logDir;
 
         this.log("codewind-filewatcher logging to " + logDir
-            + " with log level " + log.logLevelToString(LogSettings.getInstance().logLevel));
+            + " with log level " + log.logLevelToString(LogSettings.getInstance().logLevel)
+            + " on platform '" + process.platform + "'");
     }
 
     public log(str: string) {

--- a/Filewatcherd-TypeScript/src/lib/ProjectObject.ts
+++ b/Filewatcherd-TypeScript/src/lib/ProjectObject.ts
@@ -13,6 +13,7 @@ import { FileChangeEventBatchUtil } from "./FileChangeEventBatchUtil";
 import { FileWatcher } from "./FileWatcher";
 import { ProjectToWatch } from "./ProjectToWatch";
 
+import { IWatchService } from "./IWatchService";
 import * as log from "./Logger";
 
 export class ProjectObject {
@@ -21,9 +22,18 @@ export class ProjectObject {
 
     private _projectToWatch: ProjectToWatch;
 
-    public constructor(projectId: string, projectToWatch: ProjectToWatch, parent: FileWatcher) {
-        this._projectToWatch = projectToWatch;
-        this._batchUtil = new FileChangeEventBatchUtil(projectId, parent);
+    private readonly _watchService: IWatchService;
+
+    public constructor(projectId: string, projectToWatch: ProjectToWatch, watchService: IWatchService,
+                       parent: FileWatcher) {
+
+            if (!projectId || !projectToWatch || !watchService || !parent) {
+                log.severe("Missing parameters to constructor of ProjectObject!");
+            }
+
+            this._projectToWatch = projectToWatch;
+            this._batchUtil = new FileChangeEventBatchUtil(projectId, parent);
+            this._watchService = watchService;
     }
 
     public updateProjectToWatch(newProjectToWatch: ProjectToWatch) {
@@ -45,5 +55,9 @@ export class ProjectObject {
 
     public get batchUtil(): FileChangeEventBatchUtil {
         return this._batchUtil;
+    }
+
+    public get watchService(): IWatchService {
+        return this._watchService;
     }
 }

--- a/Filewatcherd-TypeScript/src/lib/ProjectToWatch.ts
+++ b/Filewatcherd-TypeScript/src/lib/ProjectToWatch.ts
@@ -27,6 +27,8 @@ export class ProjectToWatch {
 
     private readonly _projectWatchStateId: string;
 
+    private readonly _external: boolean;
+
     constructor(json: models.IWatchedProjectJson, deleteChangeType: boolean) {
 
         // Delete event from WebSocket only has these fields.
@@ -56,6 +58,8 @@ export class ProjectToWatch {
         this._ignoredFilenames = ignoredFilenames;
 
         this._projectWatchStateId = json.projectWatchStateId;
+
+        this._external = json.type ? (json.type.toLowerCase() === "non-project") : false;
     }
 
     private validatePathToMonitor() {
@@ -94,5 +98,9 @@ export class ProjectToWatch {
 
     public get projectWatchStateId(): string {
         return this._projectWatchStateId;
+    }
+
+    public get external(): boolean {
+        return this._external;
     }
 }

--- a/Filewatcherd-TypeScript/src/lib/VSCWatchedPath.ts
+++ b/Filewatcherd-TypeScript/src/lib/VSCWatchedPath.ts
@@ -24,6 +24,8 @@ export class VSCWatchedPath {
 
         this._pathRoot = pathRoot;
 
+        this._parent.parent.sendWatchResponseAsync(true, ptw);
+
     }
     public receiveFileChanges(entries: WatchEventEntry[]) {
 

--- a/Filewatcherd-TypeScript/src/lib/VSCodeResourceWatchService.ts
+++ b/Filewatcherd-TypeScript/src/lib/VSCodeResourceWatchService.ts
@@ -88,6 +88,10 @@ export class VSCodeResourceWatchService implements IWatchService {
         this._parent = parent;
     }
 
+    public get parent(): FileWatcher {
+        return this._parent;
+    }
+
     public dispose(): void {
         this._disposed = true;
         this._projIdToWatchedPaths.clear();

--- a/Filewatcherd-TypeScript/src/lib/client.ts
+++ b/Filewatcherd-TypeScript/src/lib/client.ts
@@ -19,7 +19,6 @@ import fs = require("fs");
 import os = require("os");
 import path = require("path");
 import { WatchService } from "./WatchService";
-
 /**
  *
  * @param codewindURL - Eg, http://localhost:9090
@@ -51,7 +50,8 @@ export default async function createWatcher(codewindURL: string, logDir?: string
 
     const fileLogger = new FileLogger(logDir);
 
-    console.log("codewind-filewatcher logging to " + logDir + " with log level " + log.logLevelToString(logLevel));
+    console.log("codewind-filewatcher logging to " + logDir + " with log level " + log.logLevelToString(logLevel)
+        + " on platform '" + process.platform + "'");
 
     log.LogSettings.getInstance().setFileLogger(fileLogger);
 
@@ -61,7 +61,7 @@ export default async function createWatcher(codewindURL: string, logDir?: string
 
     const clientUuid = crypto.randomBytes(16).toString("hex");
 
-    const fw = new FileWatcher(codewindURL, watchService, clientUuid);
+    const fw = new FileWatcher(codewindURL, watchService, null, clientUuid);
     return fw;
 }
 

--- a/Filewatcherd-TypeScript/src/lib/client.ts
+++ b/Filewatcherd-TypeScript/src/lib/client.ts
@@ -18,13 +18,15 @@ import crypto = require("crypto");
 import fs = require("fs");
 import os = require("os");
 import path = require("path");
+import { IWatchService } from "./IWatchService";
 import { WatchService } from "./WatchService";
 /**
  *
  * @param codewindURL - Eg, http://localhost:9090
  * @param logDir - Directory to write logs to, by default ~/.codewind.
  */
-export default async function createWatcher(codewindURL: string, logDir?: string): Promise<FileWatcher> {
+export default async function createWatcher(codewindURL: string, logDir?: string,
+                                            externalWatchService?: IWatchService): Promise<FileWatcher> {
 
     // Default log level
     let logLevel = log.LogLevel.INFO;
@@ -61,7 +63,9 @@ export default async function createWatcher(codewindURL: string, logDir?: string
 
     const clientUuid = crypto.randomBytes(16).toString("hex");
 
-    const fw = new FileWatcher(codewindURL, watchService, null, clientUuid);
+    const fw = new FileWatcher(codewindURL, watchService, (externalWatchService) ? externalWatchService : null,
+        clientUuid);
+
     return fw;
 }
 


### PR DESCRIPTION
Port updated integration logic from Java to the TypeScript filewatcher. This adds support for using different watcher for projects vs non-projects (external vs internal), and ensures that additional FW changes made since this integration code was written are correctly handled.