### PR TITLE
 Expire post data after X hours, to prevent potential memory leak

### DIFF
--- a/Filewatcherd-Go/src/codewind/fsnotify.go
+++ b/Filewatcherd-Go/src/codewind/fsnotify.go
@@ -701,7 +701,6 @@ func informWatchSuccessStatus(ptw *models.ProjectToWatch, success bool, baseURL 
 		if !success {
 			successVal = "false"
 		}
-		buffer := bytes.NewBufferString("{\"success\" : \"" + successVal + "\"}")
 
 		url := baseURL + "/api/v1/projects/" + ptw.ProjectID + "/file-changes/" + ptw.ProjectWatchStateID + "/status?clientUuid=" + service.clientUUID
 
@@ -716,7 +715,9 @@ func informWatchSuccessStatus(ptw *models.ProjectToWatch, success bool, baseURL 
 
 			client := &http.Client{Transport: tr}
 
+			buffer := bytes.NewBufferString("{\"success\" : \"" + successVal + "\"}")
 			req, err := http.NewRequest(http.MethodPut, url, buffer)
+
 			req.Header.Set("Content-Type", "application/json")
 
 			if err != nil {

--- a/Filewatcherd-Go/src/codewind/postqueuechunkgroup.go
+++ b/Filewatcherd-Go/src/codewind/postqueuechunkgroup.go
@@ -42,9 +42,10 @@ const (
  * This class is thread safe.
  */
 type PostQueueChunkGroup struct {
-	chunkMap    map[int] /*chunk id -> */ *PostQueueChunk
-	chunkStatus map[int] /*chunk id -> */ ChunkStatus
-	timestamp   int64
+	chunkMap          map[int] /*chunk id -> */ *PostQueueChunk
+	chunkStatus       map[int] /*chunk id -> */ ChunkStatus
+	timestamp         int64
+	expireTimeInNanos int64
 }
 
 /**

--- a/Filewatcherd-TypeScript/src/lib/PostQueueChunkGroup.ts
+++ b/Filewatcherd-TypeScript/src/lib/PostQueueChunkGroup.ts
@@ -44,10 +44,19 @@ export class PostQueueChunkGroup {
 
     private readonly _projectId: string;
 
-    constructor(timestamp: number, projectId: string, base64Compressed: string[], parent: HttpPostOutputQueue) {
+    /**
+     * After X hours (eg 24), give up on trying to send this chunk group to the
+     * server. At this point the data is too stale to be useful.
+     */
+    private readonly _expireTime: number;
+
+    constructor(timestamp: number, projectId: string, expireTime: number, base64Compressed: string[],
+                parent: HttpPostOutputQueue) {
+
         this._parent = parent;
         this._timestamp = timestamp;
         this._projectId = projectId;
+        this._expireTime = expireTime;
 
         let chunkId = 1;
 
@@ -136,5 +145,9 @@ export class PostQueueChunkGroup {
 
     public get projectId(): string {
         return this._projectId;
+    }
+
+    public get expireTime(): number {
+        return this._expireTime;
     }
 }


### PR DESCRIPTION
In the event of extended network disconnection, we should give up on trying to send this chunk group to the server. At this point the data is too stale to be useful.