### PR TITLE
CW #1309 - [Filewatcherd] Filewatcher unable to connect to secure PFE (via HTTP/WebSocket) without using an auth token acquired through CWCTL

### DIFF
--- a/Filewatcherd-TypeScript/src/lib/AuthTokenWrapper.ts
+++ b/Filewatcherd-TypeScript/src/lib/AuthTokenWrapper.ts
@@ -1,0 +1,98 @@
+/*******************************************************************************
+* Copyright (c) 2019 IBM Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v2.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
+
+import { FWAuthToken } from "./FWAuthToken";
+import { IAuthTokenProvider } from "./IAuthTokenProvider";
+
+import * as log from "./Logger";
+
+/**
+ * AuthTokenWrapper is the conduit through the internal filewatcher codebase
+ * requests secure authentication tokens from the IDE. In cases where the
+ * authTokenProvider is null (eg is secure auth is not required), the methods of
+ * this class are no-ops.
+ *
+ * This class was created as part of issue codewind/1309.
+ */
+export class AuthTokenWrapper {
+
+    public static readonly KEEP_LAST_X_STALE_KEYS = 10;
+
+    /**
+     * Contains an ordered (descending by creation time) list of invalids keys, with
+     * at most KEEP_LAST_X_STALE_KEYS keys.
+     */
+    private _recentInvalidKeysQueue: FWAuthToken[];
+
+    /**
+     * Contains invalid keys; used as a fast path to determine if a given key is
+     * already invalid. The should be at most KEEP_LAST_X_STALE_KEYS here.
+     */
+    private _invalidKeysSet: Set<string /* token */>;
+
+    private readonly _authTokenProvider: IAuthTokenProvider;
+
+    constructor(authTokenProvider: IAuthTokenProvider) {
+        this._authTokenProvider = authTokenProvider;
+        this._invalidKeysSet = new Set();
+    }
+    public getLatestToken(): FWAuthToken {
+        if (!this._authTokenProvider) { return null; }
+
+        const token = this._authTokenProvider.getLatestAuthToken();
+        if (!token) { return null; }
+
+        log.info("IDE returned a new security token to filewatcher: " + this.digest(token));
+
+        return token;
+    }
+
+    /** Inform the IDE when a token is rejected. */
+    public informBadToken(token: FWAuthToken): void {
+        if (!this._authTokenProvider || !token || !token.accessToken) {
+            return;
+        }
+
+        // We've already reported this key as invalid, so just return it
+        if (this._invalidKeysSet.has(token.accessToken)) {
+            log.info("Filewatcher informed us of a bad token, but we've already reported it to the IDE: "
+                + this.digest(token));
+            return;
+        }
+
+        // We have a new token that we have not previously reported as invalid.
+
+        this._invalidKeysSet.add(token.accessToken);
+        this._recentInvalidKeysQueue.push(token);
+
+        while (this._recentInvalidKeysQueue.length > AuthTokenWrapper.KEEP_LAST_X_STALE_KEYS) {
+
+            const keyToRemove = this._recentInvalidKeysQueue.shift(); // remove from end
+            this._invalidKeysSet.delete(keyToRemove.accessToken);
+        }
+
+    }
+
+    /**
+     * Return a representation of the token that is at most 32 characters long, so
+     * as not to overwhelm the log file.
+     */
+    private digest(token: FWAuthToken): string {
+        if (!token) { return null; }
+
+        const key = token.accessToken;
+        if (!key) { return null; }
+
+        return key.substring(0, Math.min(key.length, 32));
+
+    }
+
+}

--- a/Filewatcherd-TypeScript/src/lib/AuthTokenWrapper.ts
+++ b/Filewatcherd-TypeScript/src/lib/AuthTokenWrapper.ts
@@ -79,6 +79,8 @@ export class AuthTokenWrapper {
             this._invalidKeysSet.delete(keyToRemove.accessToken);
         }
 
+        this._authTokenProvider.informReceivedInvalidAuthToken(token);
+
     }
 
     /**

--- a/Filewatcherd-TypeScript/src/lib/AuthTokenWrapper.ts
+++ b/Filewatcherd-TypeScript/src/lib/AuthTokenWrapper.ts
@@ -71,11 +71,11 @@ export class AuthTokenWrapper {
         // We have a new token that we have not previously reported as invalid.
 
         this._invalidKeysSet.add(token.accessToken);
-        this._recentInvalidKeysQueue.push(token);
+        this._recentInvalidKeysQueue.push(token); // append to end
 
         while (this._recentInvalidKeysQueue.length > AuthTokenWrapper.KEEP_LAST_X_STALE_KEYS) {
 
-            const keyToRemove = this._recentInvalidKeysQueue.shift(); // remove from end
+            const keyToRemove = this._recentInvalidKeysQueue.shift(); // remove from front
             this._invalidKeysSet.delete(keyToRemove.accessToken);
         }
 

--- a/Filewatcherd-TypeScript/src/lib/FWAuthToken.ts
+++ b/Filewatcherd-TypeScript/src/lib/FWAuthToken.ts
@@ -1,0 +1,39 @@
+/*******************************************************************************
+* Copyright (c) 2019 IBM Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v2.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
+
+/**
+ * Immutable authorization token for use in HTTP(S) requests and WebSocket
+ * connections
+ */
+export class FWAuthToken {
+
+    private readonly _accessToken: string;
+
+    private readonly _tokenType: string;
+
+    constructor(accessToken: string, tokenType: string) {
+        if (!accessToken || !tokenType) {
+            throw new Error("Invalid parameters to FWAuthToken: " + accessToken + " " + tokenType);
+        }
+
+        this._accessToken = accessToken;
+        this._tokenType = tokenType;
+    }
+
+    public get accessToken(): string {
+        return this._accessToken;
+    }
+
+    public get tokenType(): string {
+        return this._tokenType;
+    }
+
+}

--- a/Filewatcherd-TypeScript/src/lib/FileWatcher.ts
+++ b/Filewatcherd-TypeScript/src/lib/FileWatcher.ts
@@ -83,7 +83,7 @@ export class FileWatcher {
 
         this._baseUrl = PathUtils.stripTrailingSlash(urlParam);
 
-        this._outputQueue = new HttpPostOutputQueue(this._baseUrl);
+        this._outputQueue = new HttpPostOutputQueue(this._baseUrl, this._authTokenWrapper);
 
         let calculatedWsUrl = this._baseUrl;
         calculatedWsUrl = calculatedWsUrl.replace("http://", "ws://");

--- a/Filewatcherd-TypeScript/src/lib/HttpGetStatusThread.ts
+++ b/Filewatcherd-TypeScript/src/lib/HttpGetStatusThread.ts
@@ -78,7 +78,16 @@ export class HttpGetStatusThread {
             rejectUnauthorized : false,
             resolveWithFullResponse: true,
             timeout: 20000,
-        };
+        } as request.RequestPromiseOptions;
+
+        const authTokenWrapper = this._parent.authTokenWrapper;
+        const authToken = authTokenWrapper.getLatestToken();
+        if (authToken && authToken.accessToken) {
+
+            options.auth = {
+                bearer: authToken.accessToken,
+            };
+        }
 
         try {
 
@@ -117,7 +126,14 @@ export class HttpGetStatusThread {
                 }
 
                 return result;
+
             } else {
+
+                // TODO: Is this the correct way to identify bad tokens?
+                if (authToken && authToken.accessToken && httpResult.statusCode && httpResult.statusCode === 403) {
+                    authTokenWrapper.informBadToken(authToken);
+                }
+
                 return null;
             }
 

--- a/Filewatcherd-TypeScript/src/lib/HttpPostOutputQueue.ts
+++ b/Filewatcherd-TypeScript/src/lib/HttpPostOutputQueue.ts
@@ -181,6 +181,7 @@ export class HttpPostOutputQueue {
 
         const options = {
             body: payload,
+            followRedirect: false,
             json: true,
             rejectUnauthorized : false,
             resolveWithFullResponse: true,
@@ -201,7 +202,8 @@ export class HttpPostOutputQueue {
 
             if (result.statusCode !== 200) {
 
-                // TODO: Is this the correct way to identify bad tokens?
+                // TODO: In the unlikely event that this class is NOT deleted when cwctl is stable, then convert
+                // this to check for 302, like the other HTTP endpoints
                 if (authToken && authToken.accessToken && result.statusCode && result.statusCode === 403) {
                     this._authTokenWrapper.informBadToken(authToken);
                 }

--- a/Filewatcherd-TypeScript/src/lib/HttpPostOutputQueue.ts
+++ b/Filewatcherd-TypeScript/src/lib/HttpPostOutputQueue.ts
@@ -12,6 +12,7 @@
 import * as request from "request-promise-native";
 import { ExponentialBackoffUtil } from "./ExponentialBackoffUtil";
 
+import { AuthTokenWrapper } from "./AuthTokenWrapper";
 import * as log from "./Logger";
 import { PostQueueChunk } from "./PostQueueChunk";
 import { PostQueueChunkGroup } from "./PostQueueChunkGroup";
@@ -49,11 +50,14 @@ export class HttpPostOutputQueue {
 
     private readonly _failureDelay: ExponentialBackoffUtil;
 
-    constructor(serverBaseUrl: string) {
+    private readonly _authTokenWrapper: AuthTokenWrapper;
+
+    constructor(serverBaseUrl: string, authTokenWrapper: AuthTokenWrapper) {
         this._serverBaseUrl = serverBaseUrl;
         this._queue = new Array<PostQueueChunkGroup>();
         this._activeRequests = 0;
         this._failureDelay = ExponentialBackoffUtil.getDefaultBackoffUtil(4000);
+        this._authTokenWrapper = authTokenWrapper;
     }
 
     public async informStateChangeAsync() {
@@ -181,13 +185,27 @@ export class HttpPostOutputQueue {
             rejectUnauthorized : false,
             resolveWithFullResponse: true,
             timeout: 20000,
-        };
+        } as request.RequestPromiseOptions;
+
+        const authToken = this._authTokenWrapper.getLatestToken();
+        if (authToken && authToken.accessToken) {
+
+            options.auth = {
+                bearer: authToken.accessToken,
+            };
+        }
 
         log.info("Issuing POST request to '" + url + "'");
         try {
             const result = await request.post(url, options);
 
             if (result.statusCode !== 200) {
+
+                // TODO: Is this the correct way to identify bad tokens?
+                if (authToken && authToken.accessToken && result.statusCode && result.statusCode === 403) {
+                    this._authTokenWrapper.informBadToken(authToken);
+                }
+
                 log.error("Unexpected error code " + result.statusCode + " from '" + url + "'");
                 return false;
             }

--- a/Filewatcherd-TypeScript/src/lib/IAuthTokenProvider.ts
+++ b/Filewatcherd-TypeScript/src/lib/IAuthTokenProvider.ts
@@ -1,0 +1,42 @@
+
+/*******************************************************************************
+* Copyright (c) 2019 IBM Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v2.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
+
+import { FWAuthToken } from "./FWAuthToken";
+
+/**
+ * The Codewind IDE classes should extends this interface to provide
+ * filewatcherd with secure authentication tokens from the IDE.
+ *
+ * This class was created as part of issue codewind/1309.
+ */
+export interface IAuthTokenProvider {
+
+    /**
+     * Return the latest auth token; return null if an auth token is not available.
+     *
+     * This method should be non-blocking (eg it should return null or stale data,
+     * rather then block on issuing a new I/O or CWCTL request to acquire a new
+     * token.)
+     */
+    getLatestAuthToken(): FWAuthToken;
+
+    /**
+     * Inform the IDE that the server told us that our current token is invalid, at
+     * which point the IDE should then re-acquire/refresh it on a separate thread.
+     * After FWd informs the IDE, the new value should be available to the FWd via a
+     * call to getLatestAuthToken() after some short period of time.
+     *
+     * Filewatcher to call `informReceivedInvalidAuthToken(...)` ONLY ONCE for a
+     * given invalid token (eg NOT every time the server informs us.)
+     */
+    informReceivedInvalidAuthToken(badToken: FWAuthToken): void;
+}

--- a/Filewatcherd-TypeScript/src/lib/WebSocketManagerThread.ts
+++ b/Filewatcherd-TypeScript/src/lib/WebSocketManagerThread.ts
@@ -105,6 +105,9 @@ export class WebSocketManagerThread {
             return;
         }
 
+        // TODO: Add token-based authentication to the WebSocket, once support is implemented server-side.
+        // (https://github.com/eclipse/codewind/issues/1342)
+
         try {
 
             if (this._previousWebSocket) {

--- a/Filewatcherd-TypeScript/src/lib/client.ts
+++ b/Filewatcherd-TypeScript/src/lib/client.ts
@@ -18,6 +18,7 @@ import crypto = require("crypto");
 import fs = require("fs");
 import os = require("os");
 import path = require("path");
+import { IAuthTokenProvider } from "./IAuthTokenProvider";
 import { IWatchService } from "./IWatchService";
 import { WatchService } from "./WatchService";
 
@@ -28,8 +29,9 @@ import { WatchService } from "./WatchService";
  * @param logDir - Directory to write logs to, by default ~/.codewind.
  */
 export default async function createWatcher(codewindURL: string, logDir?: string,
-                                            externalWatchService?: IWatchService, pathToInstaller?: string)
-                                            : Promise<FileWatcher> {
+                                            externalWatchService?: IWatchService, pathToInstaller?: string,
+                                            authTokenProvider?: IAuthTokenProvider)
+    : Promise<FileWatcher> {
 
     // Default log level
     let logLevel = log.LogLevel.INFO;
@@ -67,7 +69,7 @@ export default async function createWatcher(codewindURL: string, logDir?: string
     const clientUuid = crypto.randomBytes(16).toString("hex");
 
     const fw = new FileWatcher(codewindURL, watchService, (externalWatchService) ? externalWatchService : null,
-        pathToInstaller, clientUuid);
+        pathToInstaller, clientUuid, authTokenProvider);
 
     return fw;
 }


### PR DESCRIPTION
Parent issue: https://github.com/eclipse/codewind/issues/1309
