### PR TITLE
CW Issue 1399: Project sync support for reference to files outside of project folder

### DIFF
--- a/Filewatcherd-Go/src/codewind/individual_file_watch_service.go
+++ b/Filewatcherd-Go/src/codewind/individual_file_watch_service.go
@@ -1,0 +1,303 @@
+/*******************************************************************************
+* Copyright (c) 2020 IBM Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v2.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contribu	rs:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
+
+package main
+
+import (
+	"codewind/utils"
+	"os"
+	"strconv"
+	"time"
+)
+
+// IndividualFileWatchService is used to watch a small number of individual files, for example,
+// linked files defined in the 'refPaths' field of a watched project. For a
+// large number of files to watch, the watch service should be used instead.
+//
+// Files watched by this class do not need to exist.
+//
+// A single instance of this class will exist per filewatcher (eg it is not per
+// project).
+//
+// This class was introduced as part of 'Project sync support for reference to
+// files outside of project folder ' (codewind/1399).
+type IndividualFileWatchService struct {
+	cmdChannel  chan indivFileWatchServiceCmd
+	projectList *ProjectList
+}
+
+type indivFileWatchServiceCmdType int
+
+const (
+	iwsSetFilesToWatchCmd = iota + 1
+	iwsTimerTickCmd
+	iwsWatchServiceDispose
+)
+
+type indivFileWatchServiceCmd struct {
+	cmdType      indivFileWatchServiceCmdType
+	projectID    string
+	pathsFromPtw []string
+}
+
+// NewIndividualFileWatchService creates an instance of this service. Only one should exist per process.
+func NewIndividualFileWatchService(projectList *ProjectList) *IndividualFileWatchService {
+
+	result := &IndividualFileWatchService{
+		cmdChannel:  make(chan indivFileWatchServiceCmd),
+		projectList: projectList,
+	}
+
+	go result.commandReceiver()
+
+	return result
+}
+
+// SetFilesToWatch is used to inform the command receiver of the most recent set of files that it should be watching, for each project.
+func (ifws *IndividualFileWatchService) SetFilesToWatch(projectID string, pathsFromPtw []string) {
+	ifws.cmdChannel <- indivFileWatchServiceCmd{cmdType: iwsSetFilesToWatchCmd, projectID: projectID, pathsFromPtw: pathsFromPtw}
+}
+
+func (ifws *IndividualFileWatchService) commandReceiver() {
+	filesToWatchMap := make(map[string] /*project id*/ (map[string] /*absolute path*/ *pollEntry /*linked files*/))
+
+	// Start the channel timer
+	ifws.timerTick(filesToWatchMap, ifws.projectList)
+
+	disposed := false
+
+	for {
+		select {
+		case cmd := <-ifws.cmdChannel:
+
+			if disposed {
+				// We intentionally don't exit on dispose: doing so will blocking channel senders. The channel will be GC-ed
+				// by the runtime when there are no more consumers.
+				continue
+			}
+
+			if cmd.cmdType == iwsSetFilesToWatchCmd {
+				handleSetFilesToWatch(cmd.projectID, cmd.pathsFromPtw, filesToWatchMap)
+
+			} else if cmd.cmdType == iwsTimerTickCmd {
+				ifws.timerTick(filesToWatchMap, ifws.projectList)
+
+			} else if cmd.cmdType == iwsWatchServiceDispose {
+				disposed = true
+				for k := range filesToWatchMap {
+					delete(filesToWatchMap, k)
+				}
+			}
+		}
+	}
+}
+
+// Each X seconds, in this method we scan the list of files to watch and report changes.
+func (ifws *IndividualFileWatchService) timerTick(filesToWatchMap map[string](map[string]*pollEntry), projectList *ProjectList) {
+
+	// Maintain a list of file changes, per project
+	fileChangesDetected := make(map[string] /*project id*/ []ChangedFileEntry)
+
+	for projectID, filesToWatch := range filesToWatchMap {
+
+		// For each of the watches files for the specified projectID...
+		for _, fileToWatch := range filesToWatch {
+
+			fileModifiedTime := int64(0)
+			fileExists := true
+			file, err := os.Stat(fileToWatch.absolutePath)
+			if os.IsNotExist(err) {
+				fileExists = false
+			}
+
+			newStatus := pollEntryStatus(pollEntryStatusExists)
+			if !fileExists {
+				newStatus = pollEntryStatusDoesNotExist
+			} else {
+				fileModifiedTime = file.ModTime().UnixNano() / 1000000
+			}
+
+			if fileToWatch.lastObservedStatus != pollEntryStatusRecentlyAdded {
+
+				if fileToWatch.lastObservedStatus != newStatus {
+
+					eventType := "CREATE"
+
+					if fileExists {
+						// ADDED: Last time we saw this file it did not exist, but now it does.
+						utils.LogInfo("Watched file now exists: " + fileToWatch.absolutePath)
+						eventType = "CREATE"
+					} else {
+						// DELETED: Last time we saw this file it did exist, but it no longer does.
+						utils.LogInfo("Watched file has been deleted: " + fileToWatch.absolutePath)
+						eventType = "DELETE"
+					}
+
+					changedFiles, exists := fileChangesDetected[projectID]
+					if !exists {
+						changedFiles = []ChangedFileEntry{}
+					}
+
+					changedFileEntry, err := NewChangedFileEntry(fileToWatch.absolutePath, eventType, time.Now().UnixNano()/1000000, false)
+					if err != nil {
+						utils.LogSevereErr("Unable to create changed file entry", err)
+						continue
+					}
+
+					changedFiles = append(changedFiles, *changedFileEntry)
+
+					fileChangesDetected[projectID] = changedFiles
+
+				}
+				if fileModifiedTime > 0 && fileToWatch.lastModifiedTime > 0 && fileModifiedTime != fileToWatch.lastModifiedTime {
+
+					// CHANGED: Last time we same this file it had a different modified time.
+					utils.LogInfo("Watched file change detected: " + fileToWatch.absolutePath + " " + strconv.FormatInt(fileModifiedTime, 10) + " " + strconv.FormatInt(fileToWatch.lastModifiedTime, 10))
+
+					changedFiles, exists := fileChangesDetected[projectID]
+					if !exists {
+						changedFiles = []ChangedFileEntry{}
+					}
+
+					changedFileEntry, err := NewChangedFileEntry(fileToWatch.absolutePath, "MODIFY", time.Now().UnixNano()/1000000, false)
+					if err != nil {
+						utils.LogSevereErr("Unable to create changed file entry", err)
+						continue
+					}
+					changedFiles = append(changedFiles, *changedFileEntry)
+					fileChangesDetected[projectID] = changedFiles
+
+				}
+			} // end of if recentlyModified block
+
+			fileToWatch.lastObservedStatus = newStatus
+			fileToWatch.lastModifiedTime = fileModifiedTime
+		} // end filesToWatch iteration
+	} // end filesToWatchMap iteration
+
+	// For each of the changes we found, communicate them to the EventBatchUtil, via the project list.
+	for projectID, paths := range fileChangesDetected {
+
+		if len(paths) == 0 {
+			continue
+		}
+
+		projectList.ReceiveIndividualChangesFileList(projectID, paths)
+
+	}
+
+	// Trigger a new file checked timer tick X seconds after the previous one finishes.
+	go func() {
+		time.Sleep(time.Second * 2)
+		ifws.cmdChannel <- indivFileWatchServiceCmd{cmdType: iwsTimerTickCmd, projectID: "", pathsFromPtw: []string{}}
+
+	}()
+}
+
+// In this method we synchronize the paths that FW is telling us we should be watching, with what we are currently watching.
+func handleSetFilesToWatch(projectID string, pathsFromPtw []string, filesToWatchMap map[string](map[string]*pollEntry)) {
+
+	// Convert pathsFromPtw param to a platform-specific format (if needed), and filter out dirs
+	paths := []string{}
+	for _, pathFromPtw := range pathsFromPtw {
+		newPath, err := utils.ConvertAbsoluteUnixStyleNormalizedPathToLocalFile(pathFromPtw)
+		if err != nil {
+			utils.LogSevereErr("Unable to convert path: "+pathFromPtw, err)
+			continue
+		}
+
+		// Filter out and report directories
+		if info, err := os.Stat(newPath); err == nil && info.IsDir() {
+			utils.LogError("Project '" + projectID + "' was asked to watch a directory, which is not supported: " + newPath)
+			continue
+		}
+
+		paths = append(paths, newPath)
+	}
+
+	if len(paths) == 0 {
+		return
+	}
+
+	// mapUpdated := false
+
+	currProjectState, exists := filesToWatchMap[projectID]
+	if !exists {
+		// This is a new project we haven't seen.
+		newFiles := make(map[string]*pollEntry)
+
+		for _, path := range paths {
+			pollEntry := &pollEntry{lastObservedStatus: pollEntryStatusRecentlyAdded, absolutePath: path, lastModifiedTime: 0}
+			newFiles[pollEntry.absolutePath] = pollEntry
+			utils.LogInfo("Files to watch - recently added for new project: " + path)
+		}
+		// mapUpdated = true
+
+		filesToWatchMap[projectID] = newFiles
+	} else {
+		// This is an existing project with at least one file we are currently monitoring.
+
+		for _, path := range paths {
+
+			_, exists := currProjectState[path]
+			if !exists {
+				utils.LogInfo("Files to watch - recently added for existing project: " + path)
+				currProjectState[path] = &pollEntry{lastObservedStatus: pollEntryStatusRecentlyAdded, absolutePath: path, lastModifiedTime: 0}
+				// mapUpdated = true
+			} else {
+				// Ignore: the path is in both maps -- no change.
+			}
+		}
+
+		pathsInParam := make(map[string] /*absolute path*/ bool /*unused*/)
+		for _, path := range paths {
+			pathsInParam[path] = true
+		}
+
+		keysToRemove := []string{}
+
+		// Look for values that are in curr project state, but not in the parameter list. These are
+		// files that we WERE watching, but are no longer.
+		for pathInCurrentState := range currProjectState {
+
+			_, exists := pathsInParam[pathInCurrentState]
+			if !exists {
+				keysToRemove = append(keysToRemove, pathInCurrentState)
+				utils.LogInfo("Files to watch - removing from watch list: " + pathInCurrentState)
+				// mapUpdated = true
+			}
+		}
+
+		for _, keyToRemove := range keysToRemove {
+			delete(currProjectState, keyToRemove)
+		}
+
+		// If we're not watching anything anymore, entirely remove the project from the state list.
+		if len(currProjectState) == 0 {
+			delete(filesToWatchMap, projectID)
+		}
+	} // end existing project else
+
+} // end function
+
+type pollEntryStatus int
+
+const (
+	pollEntryStatusRecentlyAdded = iota + 1
+	pollEntryStatusExists
+	pollEntryStatusDoesNotExist
+)
+
+type pollEntry struct {
+	lastObservedStatus pollEntryStatus
+	absolutePath       string
+	lastModifiedTime   int64
+}

--- a/Filewatcherd-Go/src/codewind/models/models.go
+++ b/Filewatcherd-Go/src/codewind/models/models.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2019 IBM Corporation and others.
+* Copyright (c) 2019, 2020 IBM Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
@@ -13,21 +13,36 @@ package models
 
 // ProjectToWatch ...
 type ProjectToWatch struct {
-	IgnoredFilenames    []string `json:"ignoredFilenames"`
-	IgnoredPaths        []string `json:"ignoredPaths"`
-	PathToMonitor       string   `json:"pathToMonitor"`
-	ProjectID           string   `json:"projectID"`
-	ChangeType          string   `json:"changeType"`
-	ProjectWatchStateID string   `json:"projectWatchStateId"`
-	Type                string   `json:"type"`
-	ProjectCreationTime int64    `json:"projectCreationTime"`
+	IgnoredFilenames    []string       `json:"ignoredFilenames"`
+	IgnoredPaths        []string       `json:"ignoredPaths"`
+	PathToMonitor       string         `json:"pathToMonitor"`
+	ProjectID           string         `json:"projectID"`
+	ChangeType          string         `json:"changeType"`
+	ProjectWatchStateID string         `json:"projectWatchStateId"`
+	Type                string         `json:"type"`
+	ProjectCreationTime int64          `json:"projectCreationTime"`
+	RefPaths            []RefPathEntry `json:"refPaths"`
+}
+
+// RefPathEntry ...
+type RefPathEntry struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+// ConvertRefPathsToFromStrings is a simple utility method that converts RefPaths to an array containing only the From field of each entry
+func ConvertRefPathsToFromStrings(ptw *ProjectToWatch) []string {
+	indivFilesToWatch := []string{}
+	for _, refPath := range ptw.RefPaths {
+		indivFilesToWatch = append(indivFilesToWatch, refPath.From)
+	}
+	return indivFilesToWatch
 }
 
 // Clone performs a deep copy of a ProjectToWatch
 func (entry *ProjectToWatch) Clone() *ProjectToWatch {
 
 	var newIgnoredFilenames []string
-
 	if entry.IgnoredFilenames != nil {
 		newIgnoredFilenames = make([]string, 0)
 		for _, val := range entry.IgnoredFilenames {
@@ -36,11 +51,18 @@ func (entry *ProjectToWatch) Clone() *ProjectToWatch {
 	}
 
 	var newIgnoredPaths []string
-
 	if entry.IgnoredPaths != nil {
 		newIgnoredPaths = make([]string, 0)
 		for _, val := range entry.IgnoredPaths {
 			newIgnoredPaths = append(newIgnoredPaths, val)
+		}
+	}
+
+	var newRefPaths []RefPathEntry
+	if entry.RefPaths != nil {
+		newRefPaths = []RefPathEntry{}
+		for _, val := range entry.RefPaths {
+			newRefPaths = append(newRefPaths, RefPathEntry{From: val.From, To: val.To})
 		}
 	}
 
@@ -53,6 +75,7 @@ func (entry *ProjectToWatch) Clone() *ProjectToWatch {
 		entry.ProjectWatchStateID,
 		entry.Type,
 		entry.ProjectCreationTime,
+		newRefPaths,
 	}
 }
 

--- a/Filewatcherd-Go/src/codewind/utils/pathutils.go
+++ b/Filewatcherd-Go/src/codewind/utils/pathutils.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2019 IBM Corporation and others.
+* Copyright (c) 2019, 2020 IBM Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
@@ -229,6 +229,7 @@ func (p *PathFilter) IsFilteredOutByFilename(pathParam string) bool {
 	return false
 }
 
+// IsFilteredOutByPath ...
 func (p *PathFilter) IsFilteredOutByPath(path string) bool {
 
 	if strings.Contains(path, "\\") {
@@ -236,13 +237,17 @@ func (p *PathFilter) IsFilteredOutByPath(path string) bool {
 		return false
 	}
 
+	result := false
+
 	for _, val := range p.pathExcludePatterns {
+
 		if val.MatchString(path) {
-			return true
+			result = true
+			break
 		}
 	}
 
-	return false
+	return result
 
 }
 

--- a/Filewatcherd-TypeScript/package.json
+++ b/Filewatcherd-TypeScript/package.json
@@ -1,6 +1,6 @@
 {
     "name": "codewind-filewatcher",
-    "version": "0.6.0",
+    "version": "0.9.0",
     "description": "File change notification client that recursively monitors project directories and notifies the Codewind server of file changes",
     "repository": "https://github.com/eclipse/codewind-filewatchers/",
     "license": "EPL-2.0",

--- a/Filewatcherd-TypeScript/src/lib/AuthTokenWrapper.ts
+++ b/Filewatcherd-TypeScript/src/lib/AuthTokenWrapper.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2019 IBM Corporation and others.
+* Copyright (c) 2019, 2020 IBM Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at

--- a/Filewatcherd-TypeScript/src/lib/AuthTokenWrapper.ts
+++ b/Filewatcherd-TypeScript/src/lib/AuthTokenWrapper.ts
@@ -41,6 +41,7 @@ export class AuthTokenWrapper {
     private readonly _authTokenProvider: IAuthTokenProvider;
 
     constructor(authTokenProvider: IAuthTokenProvider) {
+        this._recentInvalidKeysQueue = new Array<FWAuthToken>();
         this._authTokenProvider = authTokenProvider;
         this._invalidKeysSet = new Set();
     }

--- a/Filewatcherd-TypeScript/src/lib/FileLogger.ts
+++ b/Filewatcherd-TypeScript/src/lib/FileLogger.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2019 IBM Corporation and others.
+* Copyright (c) 2019, 2020 IBM Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at

--- a/Filewatcherd-TypeScript/src/lib/FileLogger.ts
+++ b/Filewatcherd-TypeScript/src/lib/FileLogger.ts
@@ -89,7 +89,7 @@ export class FileLogger {
             if (this._fd === -2) { return; }
 
             if (this._fd >= 0) { // Close old file
-                fs.close(this._fd, (e) => {
+                fs.close(this._fd, (_) => {
                     console.error("Unable to close file descriptor.");
                 });
             }

--- a/Filewatcherd-TypeScript/src/lib/IndividualFileWatchService.ts
+++ b/Filewatcherd-TypeScript/src/lib/IndividualFileWatchService.ts
@@ -156,7 +156,7 @@ export class IndividualFileWatchService {
     private threadRun() {
 
         if (this._timer) {
-            clearInterval(this._timer);
+            clearTimeout(this._timer);
         }
 
         this._timer = setTimeout(() => {

--- a/Filewatcherd-TypeScript/src/lib/IndividualFileWatchService.ts
+++ b/Filewatcherd-TypeScript/src/lib/IndividualFileWatchService.ts
@@ -1,0 +1,268 @@
+
+/*******************************************************************************
+* Copyright (c) 2020 IBM Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v2.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
+
+import fs = require("fs");
+
+import { FileWatcher } from "./FileWatcher";
+import {
+    convertAbsoluteUnixStyleNormalizedPathToLocalFile,
+} from "./PathUtils";
+
+import { ChangedFileEntry } from "./ChangedFileEntry";
+import * as log from "./Logger";
+import { PollEntry } from "./PollEntry";
+import { PollEntryStatus } from "./PollEntry";
+import { EventType } from "./WatchEventEntry";
+
+/**
+ * This class is used to watch a small number of individual files, for example,
+ * linked files defined in the 'refPaths' field of a watched project. For a
+ * large number of files to watch, the watch service should be used instead.
+ *
+ * Files watched by this class do not need to exist
+ *
+ * A single instance of this class will exist per filewatcher (eg it is not per
+ * project).
+ *
+ * This class was introduced as part of 'Project sync support for reference to
+ * files outside of project folder' (codewind/1399).
+ */
+export class IndividualFileWatchService {
+
+    private _filesToWatchMap: Map<string /* project id */, Map<string /* absolute path */, PollEntry
+        /* linked files */>>;
+
+    private _filewatcher: FileWatcher;
+
+    private _disposed: boolean = false;
+
+    private _timer: NodeJS.Timer = undefined;
+
+    constructor(filewatcher: FileWatcher) {
+        this._filewatcher = filewatcher;
+        this._filesToWatchMap = new Map<string, Map<string, PollEntry>>();
+
+        this.threadRun();
+
+    }
+
+    public setFilesToWatch(projectId: string, pathsFromPtw: string[]) {
+
+        const paths: string[] = [];
+        for (const pathFromPtw of pathsFromPtw) {
+
+            const newPath = convertAbsoluteUnixStyleNormalizedPathToLocalFile(pathFromPtw);
+
+            const isDirectory = fs.existsSync(newPath) && fs.lstatSync(newPath).isDirectory();
+
+            // Filter out and report directories
+            if (isDirectory) {
+                log.error("Project '" + projectId + "' was asked to watch a directory, which is not supported: "
+                    + newPath);
+                continue;
+            }
+
+            paths.push(newPath);
+        }
+
+        if (paths.length === 0) {
+            return;
+        }
+
+        let mapUpdated = false;
+
+        const currProjectState = this._filesToWatchMap.get(projectId);
+
+        if (!currProjectState) {
+
+            // This is a new project we haven't seen.
+
+            const newFiles = new Map<string, PollEntry>();
+
+            for (const path of paths) {
+                const pollEntry = new PollEntry(PollEntryStatus.RECENTLY_ADDED, path, 0);
+                newFiles.set(pollEntry.absolutePath, pollEntry);
+                log.info("Files to watch - recently added for new project: " + path);
+            }
+            mapUpdated = true;
+
+            this._filesToWatchMap.set(projectId, newFiles);
+        } else {
+            // This is an existing project with at least one file we are currently monitoring.
+
+            for (const path of paths) {
+
+                const pe = currProjectState.get(path);
+                if (!pe) {
+
+                    log.info("Files to watch - recently added for existing project: " + path);
+                    currProjectState.set(path, new PollEntry(PollEntryStatus.RECENTLY_ADDED, path, 0));
+                    mapUpdated = true;
+
+                } else {
+                    // Ignore: the path is in both maps -- no change.
+                }
+            }
+
+            const pathsInParam = new Set<string>();
+            for (const path of paths) {
+                pathsInParam.add(path);
+            }
+
+            const keysToRemove = [];
+
+            // Look for values that are in curr project state, but not in the parameter list. These are
+            // files that we WERE watching, but are no longer.
+            for (const [pathInCurrentState, _] of currProjectState) {
+
+                if (!pathsInParam.has(pathInCurrentState)) {
+                    keysToRemove.push(pathInCurrentState);
+                    log.info("Files to watch - removing from watch list: " + pathInCurrentState);
+                    mapUpdated = true;
+                }
+            }
+            for (const keyToRemove of keysToRemove) {
+                currProjectState.delete(keyToRemove);
+            }
+
+            // If we're not watching anything anymore, remove the project from the state list.
+            if (currProjectState.size === 0) {
+                this._filesToWatchMap.delete(projectId);
+            }
+
+        } // end existing project else
+
+    } // end method
+
+    public dispose() {
+        if (this._disposed) {
+            return;
+        }
+        this._disposed = true;
+
+        this._filesToWatchMap.clear();
+
+    }
+
+    private threadRun() {
+
+        if (this._timer) {
+            clearInterval(this._timer);
+        }
+
+        this._timer = setTimeout(() => {
+            try {
+                this.innerThreadRun();
+            } catch (e) {
+                log.severe("TimerTask failed", e);
+            }
+            // Restart the timer on completion of thread.
+            if (!this._disposed) {
+                this.threadRun();
+            }
+        }, 2000);
+    }
+
+    private innerThreadRun() {
+        const fileChangesDetected = new Map<string /* project id */, Set<ChangedFileEntry>>();
+
+        const localMap = new Map<string /* project id */, PollEntry[]>();
+
+        // Clone filesToWatchMap
+        this._filesToWatchMap.forEach((watchFileState: Map<string, PollEntry>, projectId: string) => {
+
+            const pollEntriesCopy = [];
+            for (const pollEntry of watchFileState.values()) {
+                pollEntriesCopy.push(pollEntry);
+            }
+            localMap.set(projectId, pollEntriesCopy);
+        });
+
+        // For each project we are monitoring...
+        for (const [projectId, filesToWatch] of localMap) {
+            // For each watched file in that project...
+            for (const fileToWatch of filesToWatch) {
+                const fileExists = fs.existsSync(fileToWatch.absolutePath);
+                const newStatus = fileExists ? PollEntryStatus.EXISTS : PollEntryStatus.DOES_NOT_EXIST;
+
+                let fileModifiedTime = 0;
+                if (fileExists) {
+                    const stats = fs.statSync(fileToWatch.absolutePath);
+                    if (stats) {
+                        fileModifiedTime = stats.mtime.getTime();
+                    } else {
+                        log.info("Unable to read file modified time: " + fileToWatch.absolutePath);
+                    }
+                }
+
+                if (fileToWatch.lastObservedStatus !== PollEntryStatus.RECENTLY_ADDED) {
+
+                    if (fileToWatch.lastObservedStatus !== newStatus) {
+
+                        let type = EventType.CREATE;
+
+                        if (fileExists) {
+                            // ADDED: Last time we saw this file it did not exist, but now it does.
+                            log.info("Watched file now exists: " + fileToWatch.absolutePath);
+                            type = EventType.CREATE;
+                        } else {
+                            // DELETED: Last time we saw this file it did exist, but it no longer does.
+                            log.info("Watched file has been deleted: " + fileToWatch.absolutePath);
+                            type = EventType.DELETE;
+                        }
+
+                        let changedFiles = fileChangesDetected.get(projectId);
+                        if (!changedFiles) {
+                            changedFiles = new Set<ChangedFileEntry>();
+                            fileChangesDetected.set(projectId, changedFiles);
+                        }
+
+                        changedFiles.add(new ChangedFileEntry(fileToWatch.absolutePath, type,
+                            new Date().getTime(), false));
+                    }
+
+                    if (fileModifiedTime && fileModifiedTime > 0 && fileToWatch.lastModifiedDate
+                        && fileToWatch.lastModifiedDate > 0 && fileModifiedTime !== fileToWatch.lastModifiedDate) {
+
+                        // CHANGED: Last time we same this file it had a different modified time.
+                        log.info("Watched file change detected: " + fileToWatch.absolutePath + " "
+                            + fileModifiedTime + " " + fileToWatch.lastModifiedDate);
+
+                        let changedFiles = fileChangesDetected.get(projectId);
+                        if (!changedFiles) {
+                            changedFiles = new Set<ChangedFileEntry>();
+                            fileChangesDetected.set(projectId, changedFiles);
+                        }
+
+                        changedFiles.add(new ChangedFileEntry(fileToWatch.absolutePath, EventType.MODIFY,
+                            new Date().getTime(), false));
+
+                    }
+                } // end if RECENTLY_ADDED block
+
+                fileToWatch.lastObservedStatus = newStatus;
+                fileToWatch.lastModifiedDate = fileModifiedTime;
+
+            } // end filesToWatch iteration
+
+        } // end localMap iteration
+
+        for (const [projectId, paths] of fileChangesDetected) {
+            if (paths.size === 0) {
+                continue;
+            }
+
+            this._filewatcher.internal_receiveIndividualChangesFileList(projectId, paths);
+        }
+
+    } // end method
+}

--- a/Filewatcherd-TypeScript/src/lib/Models.ts
+++ b/Filewatcherd-TypeScript/src/lib/Models.ts
@@ -18,8 +18,14 @@ export interface IWatchedProjectJson {
   changeType: string;
   type: string;
   projectCreationTime: number;
+  refPaths: IRefPathEntry[];
 }
 
 export interface IWatchedProjectListJson {
   projects: IWatchedProjectJson[];
+}
+
+export interface IRefPathEntry {
+  from: string;
+  to: string;
 }

--- a/Filewatcherd-TypeScript/src/lib/PollEntry.ts
+++ b/Filewatcherd-TypeScript/src/lib/PollEntry.ts
@@ -1,0 +1,30 @@
+
+/** Struct class containing the most recent observed state of a file we have been told to watch. */
+export class PollEntry {
+    public lastObservedStatus: PollEntryStatus = PollEntryStatus.RECENTLY_ADDED;
+
+    public absolutePath: string;
+
+    // 0 if the file doesn't exist, or if the status is RECENTLY_ADDED
+    public lastModifiedDate: number = 0;
+
+    constructor(lastObservedStatus: PollEntryStatus , absolutePath: string , lastModifiedDate: number) {
+        this.lastObservedStatus = lastObservedStatus;
+        this.absolutePath = absolutePath;
+        this.lastModifiedDate = lastModifiedDate;
+    }
+}
+
+export enum PollEntryStatus {
+    /**
+     * We were recently told to watch this file and thus have not yet observed a
+     * state for it.
+     */
+    RECENTLY_ADDED,
+
+    /** File exists, last time we checked it. */
+    EXISTS,
+
+    /** File did not exist, last time we checked it. */
+    DOES_NOT_EXIST,
+}

--- a/Filewatcherd-TypeScript/src/lib/PollEntry.ts
+++ b/Filewatcherd-TypeScript/src/lib/PollEntry.ts
@@ -1,3 +1,13 @@
+/*******************************************************************************
+* Copyright (c) 2020 IBM Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v2.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
 
 /** Struct class containing the most recent observed state of a file we have been told to watch. */
 export class PollEntry {

--- a/Filewatcherd-TypeScript/src/lib/ProjectObject.ts
+++ b/Filewatcherd-TypeScript/src/lib/ProjectObject.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2019 IBM Corporation and others.
+* Copyright (c) 2019, 2020 IBM Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
@@ -63,7 +63,7 @@ export class ProjectObject {
     }
 
     public informCwctlOfFileChangesAsync() {
-        this._cliState.onFileChangeEvent(this._projectToWatch.projectCreationTimeInAbsoluteMsecs);
+        this._cliState.onFileChangeEvent(this._projectToWatch.projectCreationTimeInAbsoluteMsecs, this._projectToWatch);
     }
 
     public get projectToWatch(): ProjectToWatch {

--- a/Filewatcherd-TypeScript/src/lib/ProjectToWatch.ts
+++ b/Filewatcherd-TypeScript/src/lib/ProjectToWatch.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2019 IBM Corporation and others.
+* Copyright (c) 2019, 2020 IBM Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
@@ -46,6 +46,10 @@ export class ProjectToWatch {
 
     public get external(): boolean {
         return this._external;
+    }
+
+    public get filesToWatch(): string[] {
+        return this._filesToWatch;
     }
 
     public get projectCreationTimeInAbsoluteMsecs(): number {
@@ -108,6 +112,12 @@ export class ProjectToWatch {
         // Replace the old value, with specified parameter.
         result._projectCreationTimeInAbsoluteMsecs = projectCreationTimeInAbsoluteMsecsParam;
 
+        const filesToWatch: string[] = [];
+        if (old.filesToWatch && old.filesToWatch.length > 0) {
+            old.filesToWatch.forEach((e) => { filesToWatch.push(e); });
+        }
+        result._filesToWatch = filesToWatch;
+
     }
 
     /** Copy the values from the JSON object into the given ProjectToWatch. */
@@ -146,6 +156,12 @@ export class ProjectToWatch {
 
         result._projectCreationTimeInAbsoluteMsecs = json.projectCreationTime;
 
+        const filesToWatch: string[] = [];
+        if (json.refPaths && json.refPaths.length > 0) {
+            json.refPaths.forEach((e) => { filesToWatch.push(e.from); });
+        }
+        result._filesToWatch = filesToWatch;
+
     }
 
     /**
@@ -162,6 +178,8 @@ export class ProjectToWatch {
     private _projectWatchStateId: string;
 
     private _external: boolean;
+
+    private _filesToWatch: string[];
 
     /** undefined if project time is not specified, a >0 value otherwise. */
     private _projectCreationTimeInAbsoluteMsecs: number;

--- a/Filewatcherd-TypeScript/src/lib/WatchedPath.ts
+++ b/Filewatcherd-TypeScript/src/lib/WatchedPath.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2019 IBM Corporation and others.
+* Copyright (c) 2019, 2020 IBM Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
@@ -107,7 +107,7 @@ export class WatchedPath {
         const pathFilterConst = this._pathFilter;
 
         /** Decide what to ignore using our custom function; true if should ignore, false otherwise. */
-        const ignoreFunction = (a: string, b: any) => {
+        const ignoreFunction = (a: string, _: any) => {
             if (!a) { return false; }
 
             a = convertAbsolutePathWithUnixSeparatorsToProjectRelativePath(normalizePath(a), normalizedPathConst);
@@ -140,7 +140,7 @@ export class WatchedPath {
             .on("addDir", (path) => this.handleDirChange(path, "CREATE"))
             .on("unlinkDir", (path) => this.handleDirChange(path, "DELETE"))
             .on("error", (error) => log.severe(`Watcher error: ${error}`, error))
-            .on("raw", (event, path, details) => {
+            .on("raw", (event, path, _) => {
                 log.debug("Watcher raw event info:" + event + "|" + path);
 
                 if (path === this._pathRoot && !existsSync(path)) {

--- a/Filewatcherd-TypeScript/src/lib/WebSocketManagerThread.ts
+++ b/Filewatcherd-TypeScript/src/lib/WebSocketManagerThread.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2019 IBM Corporation and others.
+* Copyright (c) 2019, 2020 IBM Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
@@ -155,7 +155,7 @@ export class WebSocketManagerThread {
                             resolve(true);
                         });
 
-                        ws.on("error", function error(en: WebSocket, errorFromFunction: Error) {
+                        ws.on("error", function error(_en: WebSocket, errorFromFunction: Error) {
                             log.error("Error handler called on WebSocket", errorFromFunction);
                             resolve(false);
                         });

--- a/Filewatcherd-TypeScript/tsconfig.json
+++ b/Filewatcherd-TypeScript/tsconfig.json
@@ -7,6 +7,8 @@
         "sourceMap": true,
         "outDir": "dist",
         "baseUrl": ".",
+        // "strict": true,   /* enable all strict type-checking options */
+        "noUnusedParameters": true,  /* Report errors on unused parameters. */
         "paths": {
             "*": [
                 "node_modules/*",


### PR DESCRIPTION
Parent issue: https://github.com/eclipse/codewind/issues/1399

Testing (both Go FWd and Node FWd):
- Automated Filewatcherd tests all passing (both normal and chaos-engineering versions)
- Manual test of the changes in self-hosted environment to ensure no new issues were introduced
- Tested and verified that this change can go in safely without Andrew's corresponding PFE change (linked on 1399)
