### PR TITLE
Add strict type checking to Node Filewatcher

### DIFF
--- a/Filewatcherd-TypeScript/src/lib/AuthTokenWrapper.ts
+++ b/Filewatcherd-TypeScript/src/lib/AuthTokenWrapper.ts
@@ -38,18 +38,19 @@ export class AuthTokenWrapper {
      */
     private _invalidKeysSet: Set<string /* token */>;
 
-    private readonly _authTokenProvider: IAuthTokenProvider;
+    private readonly _authTokenProvider: IAuthTokenProvider | undefined;
 
-    constructor(authTokenProvider: IAuthTokenProvider) {
+    constructor(authTokenProvider: IAuthTokenProvider | undefined) {
         this._recentInvalidKeysQueue = new Array<FWAuthToken>();
         this._authTokenProvider = authTokenProvider;
         this._invalidKeysSet = new Set();
     }
-    public getLatestToken(): FWAuthToken {
-        if (!this._authTokenProvider) { return null; }
+    
+    public getLatestToken(): FWAuthToken | undefined {
+        if (!this._authTokenProvider) { return undefined; }
 
         const token = this._authTokenProvider.getLatestAuthToken();
-        if (!token) { return null; }
+        if (!token) { return undefined; }
 
         log.info("IDE returned a new security token to filewatcher: " + this.digest(token));
 
@@ -77,6 +78,11 @@ export class AuthTokenWrapper {
         while (this._recentInvalidKeysQueue.length > AuthTokenWrapper.KEEP_LAST_X_STALE_KEYS) {
 
             const keyToRemove = this._recentInvalidKeysQueue.shift(); // remove from front
+
+            if(!keyToRemove) {
+                break;
+            }
+
             this._invalidKeysSet.delete(keyToRemove.accessToken);
         }
 
@@ -88,11 +94,11 @@ export class AuthTokenWrapper {
      * Return a representation of the token that is at most 32 characters long, so
      * as not to overwhelm the log file.
      */
-    private digest(token: FWAuthToken): string {
-        if (!token) { return null; }
+    private digest(token: FWAuthToken): string | undefined {
+        if (!token) { return undefined; }
 
         const key = token.accessToken;
-        if (!key) { return null; }
+        if (!key) { return undefined; }
 
         return key.substring(0, Math.min(key.length, 32));
 

--- a/Filewatcherd-TypeScript/src/lib/AuthTokenWrapper.ts
+++ b/Filewatcherd-TypeScript/src/lib/AuthTokenWrapper.ts
@@ -45,7 +45,7 @@ export class AuthTokenWrapper {
         this._authTokenProvider = authTokenProvider;
         this._invalidKeysSet = new Set();
     }
-    
+
     public getLatestToken(): FWAuthToken | undefined {
         if (!this._authTokenProvider) { return undefined; }
 
@@ -79,7 +79,7 @@ export class AuthTokenWrapper {
 
             const keyToRemove = this._recentInvalidKeysQueue.shift(); // remove from front
 
-            if(!keyToRemove) {
+            if (!keyToRemove) {
                 break;
             }
 

--- a/Filewatcherd-TypeScript/src/lib/CLIState.ts
+++ b/Filewatcherd-TypeScript/src/lib/CLIState.ts
@@ -39,10 +39,10 @@ export class CLIState {
     private readonly _projectPath: string;
 
     /** For automated testing only */
-    private readonly _mockInstallerPath: string;
+    private readonly _mockInstallerPath: string | undefined;
 
     /** For automated testing only */
-    private _lastDebugPtwSeen: ProjectToWatch = undefined;
+    private _lastDebugPtwSeen: ProjectToWatch | undefined;
 
     constructor(projectId: string, installerPath: string, projectPath: string) {
         this._projectId = projectId;
@@ -52,7 +52,7 @@ export class CLIState {
         this._mockInstallerPath = process.env.MOCK_CWCTL_INSTALLER_PATH;
     }
 
-    public onFileChangeEvent(projectCreationTimeInAbsoluteMsecsParam: number, debugPtw: ProjectToWatch) {
+    public onFileChangeEvent(projectCreationTimeInAbsoluteMsecsParam: number | undefined, debugPtw: ProjectToWatch | undefined) {
 
         if (!this._projectPath || this._projectPath.trim().length === 0) {
             log.error("Project path passed to CLIState is empty, so ignoring file change event.");
@@ -95,7 +95,7 @@ export class CLIState {
         }
     }
 
-    private async callCLIAsync(debugPtw: ProjectToWatch) {
+    private async callCLIAsync(debugPtw: ProjectToWatch | undefined) {
 
         const DEBUG_FAKE_CMD_OUTPUT = false; // Enable this for debugging purposes.
 
@@ -141,7 +141,7 @@ export class CLIState {
         }
     }
 
-    private async runProjectCommand(debugPtw: ProjectToWatch): Promise<IRunProjectReturn> {
+    private async runProjectCommand(debugPtw: ProjectToWatch | undefined): Promise<IRunProjectReturn> {
 
         const executableDir = path.dirname(this._installerPath);
 
@@ -160,6 +160,10 @@ export class CLIState {
             args = ["--insecure", "project", "sync", "-p", this._projectPath, "-i", this._projectId, "-t",
                 "" + lastTimestamp];
         } else {
+
+            if(!debugPtw) {
+                throw new Error("debugPtw ProjectToWatch object was not defined, but is required when debug is enabled");
+            }
 
             // The filewatcher is being run in an automated test scenario: we will now run a
             // mock version of cwctl that simulates the project sync command. This mock

--- a/Filewatcherd-TypeScript/src/lib/DebugTimer.ts
+++ b/Filewatcherd-TypeScript/src/lib/DebugTimer.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2019 IBM Corporation and others.
+* Copyright (c) 2019, 2020 IBM Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
@@ -25,14 +25,8 @@ export class DebugTimer {
 
     private readonly _parent: FileWatcher;
 
-    private _timer: NodeJS.Timer;
-
     constructor(parent: FileWatcher) {
         this._parent = parent;
-
-        const debugTimer = this;
-
-        this.schedule();
     }
 
     private tick() {
@@ -60,9 +54,9 @@ export class DebugTimer {
 
     }
 
-    private schedule() {
+    public schedule() {
         const debugTimer = this;
-        this._timer = setTimeout(() => {
+        setTimeout(() => {
             debugTimer.tick();
         }, 30 * 60 * 1000);
 

--- a/Filewatcherd-TypeScript/src/lib/FileChangeEventBatchUtil.ts
+++ b/Filewatcherd-TypeScript/src/lib/FileChangeEventBatchUtil.ts
@@ -9,8 +9,7 @@
 *     IBM Corporation - initial API and implementation
 *******************************************************************************/
 
-import zlib = require("zlib");
-import { ChangedFileEntry, IChangedFileEntryJson } from "./ChangedFileEntry";
+import { ChangedFileEntry } from "./ChangedFileEntry";
 import { FileWatcher } from "./FileWatcher";
 import * as log from "./Logger";
 import { EventType } from "./WatchEventEntry";
@@ -44,11 +43,9 @@ export class FileChangeEventBatchUtil {
 
     private static readonly TIME_TO_WAIT_FOR_NO_NEW_EVENTS_IN_MSECS = 1000;
 
-    private static readonly MAX_REQUEST_SIZE_IN_PATHS = 625;
-
     private _files: ChangedFileEntry[];
 
-    private _timer: NodeJS.Timer = null;
+    private _timer: NodeJS.Timeout | undefined;
 
     private _disposed: boolean = false;
 
@@ -74,7 +71,7 @@ export class FileChangeEventBatchUtil {
             this._files.push(entry);
         }
 
-        if (this._timer != null) {
+        if (this._timer) {
             clearTimeout(this._timer);
         }
 
@@ -105,8 +102,10 @@ export class FileChangeEventBatchUtil {
         this._files = [];
 
         // Clear the timeout if it already exists.
-        clearTimeout(this._timer);
-        this._timer = null;
+        if(this._timer) {
+            clearTimeout(this._timer);
+            this._timer = undefined;
+        }
 
         if (entries.length === 0) {
             return;

--- a/Filewatcherd-TypeScript/src/lib/FileLogger.ts
+++ b/Filewatcherd-TypeScript/src/lib/FileLogger.ts
@@ -40,8 +40,6 @@ export class FileLogger {
 
     private _initialized: boolean = false;
 
-    private readonly _parent: LogSettings;
-
     public constructor(logDir: string) {
         this._logDir = logDir;
 

--- a/Filewatcherd-TypeScript/src/lib/IndividualFileWatchService.ts
+++ b/Filewatcherd-TypeScript/src/lib/IndividualFileWatchService.ts
@@ -78,8 +78,6 @@ export class IndividualFileWatchService {
             return;
         }
 
-        let mapUpdated = false;
-
         const currProjectState = this._filesToWatchMap.get(projectId);
 
         if (!currProjectState) {
@@ -93,7 +91,6 @@ export class IndividualFileWatchService {
                 newFiles.set(pollEntry.absolutePath, pollEntry);
                 log.info("Files to watch - recently added for new project: " + path);
             }
-            mapUpdated = true;
 
             this._filesToWatchMap.set(projectId, newFiles);
         } else {
@@ -106,7 +103,6 @@ export class IndividualFileWatchService {
 
                     log.info("Files to watch - recently added for existing project: " + path);
                     currProjectState.set(path, new PollEntry(PollEntryStatus.RECENTLY_ADDED, path, 0));
-                    mapUpdated = true;
 
                 } else {
                     // Ignore: the path is in both maps -- no change.
@@ -127,7 +123,6 @@ export class IndividualFileWatchService {
                 if (!pathsInParam.has(pathInCurrentState)) {
                     keysToRemove.push(pathInCurrentState);
                     log.info("Files to watch - removing from watch list: " + pathInCurrentState);
-                    mapUpdated = true;
                 }
             }
             for (const keyToRemove of keysToRemove) {

--- a/Filewatcherd-TypeScript/src/lib/IndividualFileWatchService.ts
+++ b/Filewatcherd-TypeScript/src/lib/IndividualFileWatchService.ts
@@ -45,7 +45,7 @@ export class IndividualFileWatchService {
 
     private _disposed: boolean = false;
 
-    private _timer: NodeJS.Timer = undefined;
+    private _timer: NodeJS.Timeout | undefined;
 
     constructor(filewatcher: FileWatcher) {
         this._filewatcher = filewatcher;
@@ -122,7 +122,7 @@ export class IndividualFileWatchService {
 
             // Look for values that are in curr project state, but not in the parameter list. These are
             // files that we WERE watching, but are no longer.
-            for (const [pathInCurrentState, _] of currProjectState) {
+            for (const [pathInCurrentState,] of currProjectState) {
 
                 if (!pathsInParam.has(pathInCurrentState)) {
                     keysToRemove.push(pathInCurrentState);

--- a/Filewatcherd-TypeScript/src/lib/Logger.ts
+++ b/Filewatcherd-TypeScript/src/lib/Logger.ts
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
-* Copyright (c) 2019 IBM Corporation and others.
+* Copyright (c) 2019, 2020 IBM Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
@@ -50,7 +50,7 @@ export class LogSettings {
 
     private _startTimeInMsecs: number;
 
-    private _fileLogger: FileLogger = null;
+    private _fileLogger: FileLogger | undefined;
 
     private _outputLogsToScreen: boolean = true;
 
@@ -101,7 +101,7 @@ export class LogSettings {
         this._fileLogger = fileLogger;
     }
 
-    public internalGetFileLogger(): FileLogger {
+    public internalGetFileLogger(): FileLogger | undefined {
         return this._fileLogger;
     }
 
@@ -177,7 +177,7 @@ function printOut(entry: any) {
     const outputLogsToScreen = LogSettings.getInstance().outputLogsToScreen;
 
     const fileLogger = LogSettings.getInstance().internalGetFileLogger();
-    if (fileLogger != null) {
+    if (fileLogger) {
         fileLogger.log(entry);
     }
 
@@ -199,7 +199,7 @@ function printErr(entry: any) {
         if (outputLogsToScreen) {
             console.error(msg);
         }
-        if (fileLogger != null) {
+        if (fileLogger) {
             fileLogger.log(msg);
         }
 
@@ -208,7 +208,7 @@ function printErr(entry: any) {
         if (outputLogsToScreen) {
             console.error(entry);
         }
-        if (fileLogger != null) {
+        if (fileLogger) {
             fileLogger.log(entry);
         }
 

--- a/Filewatcherd-TypeScript/src/lib/PathFilter.ts
+++ b/Filewatcherd-TypeScript/src/lib/PathFilter.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2019 IBM Corporation and others.
+* Copyright (c) 2019, 2020 IBM Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
@@ -9,7 +9,6 @@
 *     IBM Corporation - initial API and implementation
 *******************************************************************************/
 
-import path = require("path");
 import { ProjectToWatch } from "./ProjectToWatch";
 
 import * as log from "./Logger";
@@ -29,7 +28,7 @@ export class PathFilter {
 
         const filenameExcludePatterns: RegExp[] = [];
 
-        if (ptw.ignoredFilenames != null) {
+        if (ptw.ignoredFilenames) {
             ptw.ignoredFilenames.forEach((e) => {
                 if (e.indexOf("/") !== -1 || e.indexOf("\\") !== -1) {
                     log.severe("Ignored filenames may not contain path separators: " + e);
@@ -46,7 +45,7 @@ export class PathFilter {
         this._filenameExcludePatterns = filenameExcludePatterns;
 
         const pathExcludePatterns: RegExp[] = [];
-        if (ptw.ignoredPaths != null) {
+        if (ptw.ignoredPaths) {
             ptw.ignoredPaths.forEach((e) => {
                 if (e.indexOf("\\") !== -1) {
                     log.severe("Ignore paths may not contain Windows-style path separators: " + e);

--- a/Filewatcherd-TypeScript/src/lib/PathUtils.ts
+++ b/Filewatcherd-TypeScript/src/lib/PathUtils.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2019 IBM Corporation and others.
+* Copyright (c) 2019, 2020 IBM Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
@@ -178,7 +178,7 @@ export function stripTrailingSlash(str: string): string {
 // If pathToMonitor is: /home/user/codewind/project
 // and watchEventPath is: /home/user/codewind/project/some-file.txt
 // then this will convert watchEventPath to /some-file.txt
-export function convertAbsolutePathWithUnixSeparatorsToProjectRelativePath(path: string, rootPath: string): string  {
+export function convertAbsolutePathWithUnixSeparatorsToProjectRelativePath(path: string, rootPath: string): string | undefined  {
 
     if (rootPath.indexOf("\\") !== -1) {
         throw new Error("Forward slashes are not supported.");
@@ -189,15 +189,14 @@ export function convertAbsolutePathWithUnixSeparatorsToProjectRelativePath(path:
     if (!path.startsWith(rootPath)) {
         // This shouldn't happen, and is thus severe
         log.severe("Watch event '" + path + "' does not match project path '" + rootPath + "'");
-        return null;
+        return undefined;
     }
 
     path = path.replace(rootPath, "");
 
     if (path.length === 0) {
         // Ignore the empty case
-
-        return null;
+        return undefined;
     }
 
     return path;

--- a/Filewatcherd-TypeScript/src/lib/ProjectToWatch.ts
+++ b/Filewatcherd-TypeScript/src/lib/ProjectToWatch.ts
@@ -24,11 +24,27 @@ import * as PathUtils from "./PathUtils";
  */
 export class ProjectToWatch {
 
-    public get projectId(): string {
-        return this._projectId;
+    public get pathToMonitor(): string {
+        // While it's possible for _pathToMonitor to be null (in the very narrow WebSocket case), in the vast
+        // majority of cases it will never be null; anything that calls the getter should
+        // expect that it won't be. See 'optionalPathToMonitor' to get the actual value.
+        if (!this._pathToMonitor) {
+            throw new Error("pathToMonitor field id is null: " + this);
+        }
+
+        return this._pathToMonitor as string;
     }
 
-    public get pathToMonitor(): string {
+    public get projectId(): string {
+
+        // See pathToMonitor() comment; the same applies here.
+        if (!this._projectId) {
+            throw new Error("projectId field is null: " + this);
+        }
+        return this._projectId as string;
+    }
+
+    public optionalPathToMonitor() : string | undefined {
         return this._pathToMonitor;
     }
 
@@ -40,7 +56,7 @@ export class ProjectToWatch {
         return this._ignoredFilenames;
     }
 
-    public get projectWatchStateId(): string {
+    public get projectWatchStateId(): string | undefined {
         return this._projectWatchStateId;
     }
 
@@ -52,7 +68,7 @@ export class ProjectToWatch {
         return this._filesToWatch;
     }
 
-    public get projectCreationTimeInAbsoluteMsecs(): number {
+    public get projectCreationTimeInAbsoluteMsecs(): number | undefined {
         return this._projectCreationTimeInAbsoluteMsecs;
     }
 
@@ -68,7 +84,7 @@ export class ProjectToWatch {
      * but replace the projectCreationTimeInAbsoluteMsecs param
      */
     public static cloneWithNewProjectCreationTime(old: ProjectToWatch,
-                                                  projectCreationTimeInAbsoluteMsecsParam: number): ProjectToWatch {
+        projectCreationTimeInAbsoluteMsecsParam: number): ProjectToWatch {
 
         // if (old instanceof ProjectToWatchFromWebSocket) {
         //     // Sanity test
@@ -86,7 +102,7 @@ export class ProjectToWatch {
      * Called only by above method, and from ProjectToWatchFromWebSocket.
      */
     protected static copyWithNewProjectCreationTime(result: ProjectToWatch, old: ProjectToWatch,
-                                                    projectCreationTimeInAbsoluteMsecsParam: number) {
+        projectCreationTimeInAbsoluteMsecsParam: number) {
 
         result._external = old.external;
 
@@ -122,13 +138,13 @@ export class ProjectToWatch {
 
     /** Copy the values from the JSON object into the given ProjectToWatch. */
     protected static innerCreateFromJson(result: ProjectToWatch, json: models.IWatchedProjectJson,
-                                         deleteChangeType: boolean) {
+        deleteChangeType: boolean) {
 
         // Delete event from WebSocket only has these fields.
         if (deleteChangeType) {
             result._projectId = json.projectID;
-            result._pathToMonitor = null;
-            result._projectWatchStateId = null;
+            result._pathToMonitor = undefined;
+            result._projectWatchStateId = undefined;
             return;
         }
 
@@ -169,24 +185,29 @@ export class ProjectToWatch {
      * However, the fields are not read-only because we need multiple constructing methods.
      */
 
-    private _projectId: string;
-    private _pathToMonitor: string;
+    private _projectId: string | undefined;
 
-    private _ignoredPaths: string[];
-    private _ignoredFilenames: string[];
+    private _pathToMonitor: string | undefined;
 
-    private _projectWatchStateId: string;
+    private _ignoredPaths: string[] = [];
+    private _ignoredFilenames: string[] = [];
 
-    private _external: boolean;
+    private _projectWatchStateId: string | undefined;
 
-    private _filesToWatch: string[];
+    private _external: boolean = false;
+
+    private _filesToWatch: string[] = [];
 
     /** undefined if project time is not specified, a >0 value otherwise. */
-    private _projectCreationTimeInAbsoluteMsecs: number;
+    private _projectCreationTimeInAbsoluteMsecs: number | undefined;
 
     protected constructor() { }
 
     private validatePathToMonitor() {
+
+        if (!this._pathToMonitor) {
+            throw new Error("Path to monitor should be defiend: " + this._pathToMonitor)
+        }
 
         if (this._pathToMonitor.indexOf("\\") !== -1) {
             throw new Error(

--- a/Filewatcherd-TypeScript/src/lib/ProjectToWatchFromWebSocket.ts
+++ b/Filewatcherd-TypeScript/src/lib/ProjectToWatchFromWebSocket.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2019 IBM Corporation and others.
+* Copyright (c) 2019, 2020 IBM Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
@@ -30,29 +30,23 @@ export class ProjectToWatchFromWebSocket extends ProjectToWatch {
                                                            projectCreationTimeInAbsoluteMsecsParam: number)
         : ProjectToWatchFromWebSocket {
 
-        const result = new ProjectToWatchFromWebSocket();
+        const result = new ProjectToWatchFromWebSocket(old._changeType);
 
         ProjectToWatch.copyWithNewProjectCreationTime(result, old, projectCreationTimeInAbsoluteMsecsParam);
-
-        result._changeType = old._changeType;
-
         return result;
     }
 
     public static create(json: models.IWatchedProjectJson): ProjectToWatchFromWebSocket {
-        const result = new ProjectToWatchFromWebSocket();
+        const result = new ProjectToWatchFromWebSocket(json.changeType);
         ProjectToWatch.innerCreateFromJson(result, json, json.changeType.toLowerCase() === "delete");
-        result._changeType = json.changeType;
 
         return result;
     }
 
     private _changeType: string;
 
-    protected constructor() {
-        // json: models.IWatchedProjectJson
+    protected constructor(changeType : string) {
         super();
-        // super(json, json.changeType.toLowerCase() === "delete");
-        // this._changeType = json.changeType;
+        this._changeType = changeType;
     }
 }

--- a/Filewatcherd-TypeScript/src/lib/StandaloneClient.ts
+++ b/Filewatcherd-TypeScript/src/lib/StandaloneClient.ts
@@ -13,4 +13,4 @@ import clientns from "./client";
 
 /** This file will start the filewatcher when doing standalone development eg outside the VSCode integration scenario */
 
-clientns(process.env.CODEWIND_URL_ROOT, undefined, undefined, process.env.MOCK_CWCTL_INSTALLER_PATH);
+clientns(process.env.CODEWIND_URL_ROOT || "http://localhost:9090", process.env.MOCK_CWCTL_INSTALLER_PATH || "", undefined, undefined);

--- a/Filewatcherd-TypeScript/src/lib/VSCWatchedPath.ts
+++ b/Filewatcherd-TypeScript/src/lib/VSCWatchedPath.ts
@@ -1,3 +1,15 @@
+
+/*******************************************************************************
+* Copyright (c) 2019, 2020 IBM Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v2.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
+
 import { PathFilter } from "./PathFilter";
 import * as pathutils from "./PathUtils";
 import { ProjectToWatch } from "./ProjectToWatch";
@@ -33,7 +45,11 @@ export class VSCWatchedPath {
 
         this._pathRoot = pathRoot;
 
-        this._parent.parent.sendWatchResponseAsync(true, ptw);
+        if(this._parent.parent) {
+            this._parent.parent.sendWatchResponseAsync(true, ptw);
+        } else {
+            throw new Error("VSCWatchedPath's watch service parent reference is invalid.");
+        }
 
     }
     public receiveFileChanges(entries: WatchEventEntry[]) {

--- a/Filewatcherd-TypeScript/src/lib/VSCodeResourceWatchService.ts
+++ b/Filewatcherd-TypeScript/src/lib/VSCodeResourceWatchService.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2019 IBM Corporation and others.
+* Copyright (c) 2019, 2020 IBM Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
@@ -30,7 +30,7 @@ export class VSCodeResourceWatchService implements IWatchService {
 
     private readonly _projIdToWatchedPaths = new Map<string /* project Id to Watched Path */, VSCWatchedPath>();
 
-    private _parent: FileWatcher;
+    private _parent: FileWatcher | undefined;
 
     private _disposed: boolean = false;
 
@@ -72,7 +72,7 @@ export class VSCodeResourceWatchService implements IWatchService {
 
     public receiveWatchEntries(cwProjectId: string, entries: WatchEventEntry[]) {
 
-        const wp: VSCWatchedPath  = this._projIdToWatchedPaths.get(cwProjectId);
+        const wp: VSCWatchedPath | undefined  = this._projIdToWatchedPaths.get(cwProjectId);
         if (wp) {
             wp.receiveFileChanges(entries);
         } else {
@@ -88,7 +88,13 @@ export class VSCodeResourceWatchService implements IWatchService {
             log.info("Received event " + event.toString());
 
             const timeReceived = Math.round(new Date().getTime());
-            this._parent.receiveNewWatchEventEntry(event, timeReceived);
+
+            if(this._parent) {
+                this._parent.receiveNewWatchEventEntry(event, timeReceived);
+            } else {
+                log.severe("Parent not defined in VSCodeResourceWatchService.");
+            }
+
         } catch (e) {
             log.severe("handleEvent caught an uncaught exception.", e);
         }
@@ -98,7 +104,7 @@ export class VSCodeResourceWatchService implements IWatchService {
         this._parent = parent;
     }
 
-    public get parent(): FileWatcher {
+    public get parent(): FileWatcher | undefined {
         return this._parent;
     }
 

--- a/Filewatcherd-TypeScript/src/lib/WatchEventEntry.ts
+++ b/Filewatcherd-TypeScript/src/lib/WatchEventEntry.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2019 IBM Corporation and others.
+* Copyright (c) 2019, 2020 IBM Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
@@ -26,8 +26,9 @@ export function eventTypetoString(type: EventType): string {
     } else if (type === EventType.DELETE) {
         return "DELETE";
     } else {
-        log.severe("Unable to convert event type to string - " + type);
-        return null;
+        const msg = "Unable to convert event type to string - " + type;
+        log.severe(msg);
+        throw new Error(msg);
     }
 
 }
@@ -40,8 +41,9 @@ export function getEventTypeFromString(str: string): EventType {
     } else if (str === "DELETE") {
         return EventType.DELETE;
     } else {
-        log.severe("Unable to find event type: this shouldn't happen - " + str);
-        return null;
+        const msg = "Unable to find event type: this shouldn't happen - " + str;
+        log.severe(msg);
+        throw new Error(msg);
     }
 }
 

--- a/Filewatcherd-TypeScript/src/lib/WatchService.ts
+++ b/Filewatcherd-TypeScript/src/lib/WatchService.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2019 IBM Corporation and others.
+* Copyright (c) 2019, 2020 IBM Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
@@ -26,7 +26,7 @@ import { ProjectToWatch } from "./ProjectToWatch";
  */
 export class WatchService implements IWatchService {
 
-    private _parent: FileWatcher;
+    private _parent: FileWatcher | undefined;
 
     private readonly _watchedProjects: Map<string /* project id of watched project */, WatchedPath>;
 
@@ -80,7 +80,13 @@ export class WatchService implements IWatchService {
             log.info("Received event " + event.toString());
 
             const timeReceived = Math.round(new Date().getTime());
-            this._parent.receiveNewWatchEventEntry(event, timeReceived);
+
+            if(this._parent) {
+                this._parent.receiveNewWatchEventEntry(event, timeReceived);
+            } else {
+                log.severe("Watch server parent was null thus event could not be passed.")
+            }
+
         } catch (e) {
             log.severe("handleEvent caught an uncaught exception.", e);
         }
@@ -93,7 +99,7 @@ export class WatchService implements IWatchService {
 
         this._disposed = true;
 
-        for (const [_, value] of this._watchedProjects) {
+        for (const [, value] of this._watchedProjects) {
             value.dispose();
         }
     }

--- a/Filewatcherd-TypeScript/src/lib/client.ts
+++ b/Filewatcherd-TypeScript/src/lib/client.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2019 IBM Corporation and others.
+* Copyright (c) 2019, 2020 IBM Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
@@ -28,8 +28,8 @@ import { WatchService } from "./WatchService";
  * @param codewindURL - Eg, http://localhost:9090
  * @param logDir - Directory to write logs to, by default ~/.codewind.
  */
-export default async function createWatcher(codewindURL: string, logDir?: string,
-                                            externalWatchService?: IWatchService, pathToInstaller?: string,
+export default async function createWatcher(codewindURL: string, pathToInstaller: string, logDir?: string,
+                                            externalWatchService?: IWatchService,
                                             authTokenProvider?: IAuthTokenProvider)
     : Promise<FileWatcher> {
 
@@ -67,11 +67,15 @@ export default async function createWatcher(codewindURL: string, logDir?: string
 
     }
 
+    if(pathToInstaller.trim().length === 0) {
+        throw new Error("Path to installer must be specified.");
+    }
+
     const watchService = new WatchService();
 
     const clientUuid = crypto.randomBytes(16).toString("hex");
 
-    const fw = new FileWatcher(codewindURL, watchService, (externalWatchService) ? externalWatchService : null,
+    const fw = new FileWatcher(codewindURL, watchService, (externalWatchService) ? externalWatchService : undefined,
         pathToInstaller, clientUuid, authTokenProvider);
 
     return fw;

--- a/Filewatcherd-TypeScript/tsconfig.json
+++ b/Filewatcherd-TypeScript/tsconfig.json
@@ -7,8 +7,17 @@
         "sourceMap": true,
         "outDir": "dist",
         "baseUrl": ".",
-        // "strict": true,   /* enable all strict type-checking options */
-        "noUnusedParameters": true,  /* Report errors on unused parameters. */
+
+        /* Strict Type-Checking Option */
+        "strict": true, /* enable all strict type-checking options */
+
+        /* Additional Checks */
+        "noUnusedLocals": true, /* Report errors on unused locals. */
+        "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
+        "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
+        "noUnusedParameters": true, /* Report errors on unused parameters. */
+        "forceConsistentCasingInFileNames": true,
+        
         "paths": {
             "*": [
                 "node_modules/*",

--- a/Tests/FilewatcherTests/src/org/eclipse/codewind/filewatchers/test/tests/AbstractTest.java
+++ b/Tests/FilewatcherTests/src/org/eclipse/codewind/filewatchers/test/tests/AbstractTest.java
@@ -270,6 +270,14 @@ public class AbstractTest {
 		return fileToDelete;
 	}
 
+	void deleteFile(File f) {
+		boolean deleteResult = f.delete();
+
+		if (f.exists()) {
+			fail("File still exists after deletion:" + f.getName() + ", delete result was " + deleteResult);
+		}
+	}
+
 	void waitForWatcherSuccess(ProjectToWatchJson ptw) {
 
 		log.out("Waiting for watcher success: " + ptw.getProjectID() + " (" + ptw.getProjectWatchStateId() + ")");
@@ -551,6 +559,8 @@ public class AbstractTest {
 				fail("Some " + eventTypeParam.name() + " matches not found: " + matches + "/" + filesWaitingFor.size()
 						+ " Missing: " + missing);
 
+			} else {
+				System.out.println("Succcessfully matched " + matches + " files.");
 			}
 		});
 

--- a/Tests/FilewatcherTests/src/org/eclipse/codewind/filewatchers/test/tests/FilewatcherTests.java
+++ b/Tests/FilewatcherTests/src/org/eclipse/codewind/filewatchers/test/tests/FilewatcherTests.java
@@ -310,7 +310,7 @@ public class FilewatcherTests extends AbstractTest {
 		waitForEventsFromFileList(files, EventType.CREATE, p1);
 
 		for (File f : files) {
-			f.delete();
+			deleteFile(f);
 			optionalArtificialDelay();
 		}
 		waitForEventsFromFileList(files, EventType.DELETE, p1);


### PR DESCRIPTION
**Note**:  `createWatcher(...)` signature has [changed](https://github.com/eclipse/codewind-filewatchers/pull/66/files#diff-8cb7b9d7b579ebf31a165c4095711d70).

**Migration required**:

This line
https://github.com/eclipse/codewind-vscode/blob/fac9fbb00e740f0bf27f15ce768e375cb888b309/dev/src/codewind/connection/Connection.ts#L208
should change to, I believe:
`return CreateFileWatcher(this.url.toString(), cliPath, Log.getLogDir);`


This line
https://github.com/eclipse/codewind-vscode/blob/6991172281d5b5a7956e07a3aa018987c314e2c0/dev/src/codewind/connection/RemoteConnection.ts#L157
should change to, I believe:
`return CreateFileWatcher(this.url.toString(), cliPath, Log.getLogDir, undefined, { .. } )`

