### PR TITLE
CW Issue #1139 - TS filewatcher watching deleted projects longer than needed, when project list is empty

### DIFF
--- a/Filewatcherd-TypeScript/src/lib/HttpGetStatusThread.ts
+++ b/Filewatcherd-TypeScript/src/lib/HttpGetStatusThread.ts
@@ -180,7 +180,8 @@ export class HttpGetStatusThread {
 
             }
 
-            if (result && result.length > 0) {
+            // We pass 'result' even if it is empty, as an empty array implies previously watched projects are no longer watched.
+            if (result) {
                 this._parent.updateFileWatchStateFromGetRequest(result);
             }
 


### PR DESCRIPTION
Parent issue: https://github.com/eclipse/codewind/issues/1139