### PR TITLE
Add PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/where-to-report-issues.md
+++ b/.github/ISSUE_TEMPLATE/where-to-report-issues.md
@@ -1,0 +1,16 @@
+---
+name: "⚠️ Where to report issues?"
+about: File issues in the main Eclipse Codewind repository at https://github.com/eclipse/codewind/issues
+title: Issues need to be filed in the main Eclipse Codewind repository
+labels: ''
+assignees: ''
+
+---
+
+## Where to report issues?
+
+This repository is not used for issue tracking of the Codewind plugin for VSCode
+
+🚨 Please don't submit new issues here. 🚨
+
+All issues for the Codewind plugin for VSCode are managed at [https://github.com/eclipse/codewind/issues](https://github.com/eclipse/codewind/issues).

--- a/.github/PULL_REQUEST_TEMPLATE.MD
+++ b/.github/PULL_REQUEST_TEMPLATE.MD
@@ -1,0 +1,16 @@
+## What type of PR is this ? 
+
+- [ ] Bug fix
+- [ ] Enhancement
+
+## What does this PR do ?
+
+
+## Which issue(s) does this PR fix ?
+
+#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
+
+## Does this PR require a documentation change ?
+
+
+## Any special notes for your reviewer ?

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The intent of this service is to provide mechanism for clients, e.g. IDEs or Che
 
 ## Contributing
 We welcome submitting issues and contributions.
-1. [Submitting bugs](https://github.com/eclipse/codewind-filewatchers/issues)
+1. [Submitting bugs](https://github.com/eclipse/codewind/issues)
 2. [Contributing](CONTRIBUTING.md)
 
 ## Developing


### PR DESCRIPTION
Signed-off-by: Julie Stalley <julie_stalley@uk.ibm.com>

Adds our standard PR/issue template to this repository. 

For issue https://github.com/eclipse/codewind/issues/2246